### PR TITLE
refactor: 엔티티 연관관계 적 및 관련 로직 수정

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -238,11 +238,12 @@ Block {
 
 ### 설명
 - 영속 기본 키 컬럼명은 `block_id`를 사용한다.
-- `documentId`: 블록이 속한 문서
-- `parentId`: 상위 블록 ID. `null`이면 문서 루트 블록
+- `documentId`: 블록이 속한 문서 ID. 영속 구현에서는 `document_id` FK로 `Document`를 참조한다.
+- `parentId`: 상위 블록 ID. `null`이면 문서 루트 블록. 영속 구현에서는 `parent_id` self FK로 상위 `Block`을 참조한다.
 - `sortKey`: 같은 부모 아래 블록 순서 정렬용 키
 - `text`: TEXT 블록의 본문. plain string only
 - `version`: 낙관적 락용 버전
+- 물리 스키마의 `document_id`, `parent_id` FK는 hard delete 시 dangling block이 남지 않도록 `ON DELETE CASCADE`를 사용한다. 비즈니스 삭제 정책 자체는 soft delete를 우선한다.
 
 ---
 
@@ -274,6 +275,7 @@ Block {
 6. 자기 자신을 부모 블록으로 둘 수 없다.
 7. 순환 참조(cycle)는 허용하지 않는다.
 8. 다른 문서의 블록을 부모로 둘 수 없다.
+9. 물리 삭제가 필요한 운영/테스트 정리 상황에서는 상위 블록 또는 소속 문서 hard delete 시 하위 블록 FK가 함께 정리되어 dangling reference가 남지 않아야 한다.
 
 ## 7.3 사용자 참조 규칙
 1. 쓰기 작업은 인증된 사용자만 수행할 수 있다.

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -210,11 +210,12 @@ Document {
 
 ### 설명
 - 영속 기본 키 컬럼명은 `document_id`를 사용한다.
-- `workspaceId`: 문서가 속한 워크스페이스
-- `parentId`: 상위 문서 ID. `null`이면 루트 문서
+- `workspaceId`: 문서가 속한 워크스페이스 ID. 영속 구현에서는 `workspace_id` FK로 `Workspace`를 참조한다.
+- `parentId`: 상위 문서 ID. `null`이면 루트 문서. 영속 구현에서는 `parent_id` self FK로 상위 `Document`를 참조한다.
 - `sortKey`: 같은 부모 아래 문서 순서 정렬용 필수 키
 - `version`: 낙관적 락용 버전
 - `deletedAt`: soft delete 시각
+- 물리 스키마의 `parent_id` FK는 hard delete 시 하위 문서를 정리할 수 있도록 `ON DELETE CASCADE`를 사용한다. 이는 운영/테스트 정리용 안전장치이며, 비즈니스 삭제 정책 자체는 soft delete를 우선한다.
 
 ## 6.4 Block
 
@@ -258,10 +259,11 @@ Block {
 2. 하위 문서는 반드시 같은 `workspaceId` 내 부모 문서를 가져야 한다.
 3. soft delete된 문서는 기본 조회에서 제외한다.
 4. 문서를 삭제하면 해당 문서의 블록도 함께 soft delete 처리해야 한다.
-5. 하위 문서 cascade delete 여부는 제품 정책으로 확정해야 하나, v1에서는 **하위 문서까지 soft delete**를 권장한다.
-6. 자기 자신을 부모 문서로 둘 수 없다.
-7. 순환 참조(cycle)는 허용하지 않는다.
-8. 같은 형제 집합(sibling scope) 내 활성 문서의 `sortKey`는 유일해야 한다.
+5. 물리 삭제가 필요한 운영/테스트 정리 상황에서는 부모 문서 hard delete 시 하위 문서 FK가 함께 정리되어 계층 dangling reference가 남지 않아야 한다.
+6. 하위 문서 cascade delete 여부는 제품 정책으로 확정해야 하나, v1에서는 **하위 문서까지 soft delete**를 권장한다.
+7. 자기 자신을 부모 문서로 둘 수 없다.
+8. 순환 참조(cycle)는 허용하지 않는다.
+9. 같은 형제 집합(sibling scope) 내 활성 문서의 `sortKey`는 유일해야 한다.
 
 ## 7.2 블록 규칙
 1. `parentId IS NULL`이면 문서 루트 블록이다.

--- a/docs/decisions/009-map-document-hierarchy-with-jpa-associations-and-db-cascade.md
+++ b/docs/decisions/009-map-document-hierarchy-with-jpa-associations-and-db-cascade.md
@@ -1,0 +1,33 @@
+# ADR 009: Document 계층은 JPA 연관관계와 DB cascade FK로 매핑한다
+
+## 상태
+
+채택됨
+
+## 배경
+
+기존 `Document` 엔티티는 `workspaceId`, `parentId`를 단순 UUID 컬럼으로만 보관했다.
+이 구조는 API 계약을 구현하는 데는 충분했지만, JPA 차원에서 워크스페이스-문서, 문서-하위문서 계층을 모델링하지 못해 다음 문제가 있었다.
+
+- 부모/자식 무결성 검증이 서비스 계층 UUID 비교에 과도하게 의존한다.
+- 문서 계층 삭제 정리 시 FK 레벨 cascade 규칙을 명시적으로 표현하기 어렵다.
+- 테스트/운영 정리 시 hard delete가 발생하면 self hierarchy dangling reference 가능성을 스키마가 직접 막지 못한다.
+
+## 결정
+
+- `Document.workspace`는 `@ManyToOne(fetch = LAZY, optional = false)`로 `Workspace`를 참조한다.
+- `Document.parent`는 `@ManyToOne(fetch = LAZY)`로 상위 `Document`를 참조한다.
+- `Document.children`는 `@OneToMany(mappedBy = "parent", cascade = REMOVE)`로 역방향 계층을 표현한다.
+- `Document.parent` FK에는 Hibernate `@OnDelete(CASCADE)`를 적용해 물리 스키마의 `parent_id`에 `ON DELETE CASCADE`를 생성한다.
+- 외부 API와 서비스 입력 계약은 기존처럼 `workspaceId`, `parentId` UUID 중심으로 유지하되, 엔티티는 연관 엔티티를 기준으로 동작하고 `getWorkspaceId()`, `getParentId()`로 호환 값을 노출한다.
+- `@ManyToOne` 자체에는 `CascadeType.REMOVE`를 두지 않는다. 그 방식은 자식 삭제 시 부모 삭제로 전파되어 원하는 방향과 반대이기 때문이다.
+
+## 영향
+
+- 장점:
+  - 문서 계층이 엔티티 모델과 스키마에 직접 반영되어 무결성이 더 분명해진다.
+  - 부모 문서 hard delete 시 하위 문서가 DB 레벨에서 함께 정리된다.
+  - API 응답/요청 계약은 유지하면서 내부 구현만 연관관계 기반으로 개선할 수 있다.
+- 단점:
+  - `documents-core`가 Hibernate annotation을 직접 사용하므로 `hibernate-core` 의존성이 필요하다.
+  - 연관관계 조회와 flush 타이밍을 잘못 다루면 불필요한 update/version 증가가 생길 수 있어 서비스 로직에서 조회 중복을 줄여야 한다.

--- a/docs/decisions/010-map-block-hierarchy-with-jpa-associations-and-db-cascade.md
+++ b/docs/decisions/010-map-block-hierarchy-with-jpa-associations-and-db-cascade.md
@@ -1,0 +1,33 @@
+# ADR 010: Block 계층은 JPA 연관관계와 DB cascade FK로 매핑한다
+
+## 상태
+
+채택됨
+
+## 배경
+
+기존 `Block` 엔티티는 `documentId`, `parentId`를 단순 UUID 컬럼으로만 보관했다.
+이 구조는 API 계약 유지에는 충분했지만, 블록 트리와 문서 소속을 JPA 차원에서 직접 모델링하지 못해 다음 문제가 있었다.
+
+- 부모 블록/문서 무결성 검증이 서비스 계층 UUID 비교에 과도하게 의존한다.
+- 문서 hard delete 또는 블록 계층 정리 시 FK 레벨 cascade 규칙을 스키마가 직접 표현하지 못한다.
+- 테스트/운영 정리에서 direct delete가 발생하면 block self hierarchy와 document 소속 FK에 dangling reference 위험이 남는다.
+
+## 결정
+
+- `Block.document`는 `@ManyToOne(fetch = LAZY, optional = false)`로 `Document`를 참조한다.
+- `Block.parent`는 `@ManyToOne(fetch = LAZY)`로 상위 `Block`을 참조한다.
+- `Block.children`는 `@OneToMany(mappedBy = "parent", cascade = REMOVE)`로 역방향 계층을 표현한다.
+- `Block.document`, `Block.parent` FK에는 Hibernate `@OnDelete(CASCADE)`를 적용해 물리 스키마의 `document_id`, `parent_id`에 `ON DELETE CASCADE`를 생성한다.
+- 외부 API와 서비스 입력 계약은 기존처럼 `documentId`, `parentId` UUID 중심으로 유지하되, 엔티티는 연관 엔티티를 기준으로 동작하고 `getDocumentId()`, `getParentId()`로 호환 값을 노출한다.
+- `@ManyToOne` 자체에는 `CascadeType.REMOVE`를 두지 않는다. 그 방식은 자식 삭제 시 부모 삭제로 전파되어 원하는 방향과 반대이기 때문이다.
+
+## 영향
+
+- 장점:
+  - 블록 트리와 문서 소속이 엔티티 모델/스키마에 직접 드러난다.
+  - 문서 또는 부모 블록 hard delete 시 하위 블록이 DB 레벨에서 함께 정리된다.
+  - API 계약은 유지하면서 내부 로직을 연관관계 중심으로 단순화할 수 있다.
+- 단점:
+  - `documents-core`가 Hibernate annotation을 직접 사용하므로 `hibernate-core` 의존성에 계속 의존한다.
+  - 서비스에서 같은 부모/문서를 중복 조회하면 불필요한 flush나 version 증가가 생길 수 있어 조회 중복을 줄여야 한다.

--- a/docs/runbook/DEBUG.md
+++ b/docs/runbook/DEBUG.md
@@ -17,6 +17,7 @@
 13. API 통합 테스트는 저장소 루트에서 `./gradlew :documents-boot:test`로 실행한다. 하위 모듈 검증이 필요하면 같은 방식으로 `:documents-api:test`, `:documents-core:test`, `:documents-infrastructure:test`를 선택 실행한다.
 14. 빠른 API 계약 확인은 `./gradlew :documents-api:test`, 영속/서비스 구현 확인은 `./gradlew :documents-infrastructure:test`를 우선 사용하고, 최종 조립 확인 시 `:documents-boot:test`를 실행한다.
 15. 스키마 명명 규칙 확인이 필요하면 H2 `INFORMATION_SCHEMA.COLUMNS` 또는 MySQL `information_schema.columns`에서 `workspaces.workspace_id`, `documents.document_id`, `blocks.block_id` 컬럼이 생성됐는지 확인한다.
+16. 문서 계층 삭제 이슈를 확인할 때는 `information_schema.table_constraints`, `information_schema.referential_constraints`에서 `FK_DOCUMENTS_PARENT`가 존재하는지와 `DELETE_RULE = CASCADE`인지 함께 확인한다.
 
 ## 확인할 로그
 

--- a/docs/runbook/DEBUG.md
+++ b/docs/runbook/DEBUG.md
@@ -18,6 +18,7 @@
 14. 빠른 API 계약 확인은 `./gradlew :documents-api:test`, 영속/서비스 구현 확인은 `./gradlew :documents-infrastructure:test`를 우선 사용하고, 최종 조립 확인 시 `:documents-boot:test`를 실행한다.
 15. 스키마 명명 규칙 확인이 필요하면 H2 `INFORMATION_SCHEMA.COLUMNS` 또는 MySQL `information_schema.columns`에서 `workspaces.workspace_id`, `documents.document_id`, `blocks.block_id` 컬럼이 생성됐는지 확인한다.
 16. 문서 계층 삭제 이슈를 확인할 때는 `information_schema.table_constraints`, `information_schema.referential_constraints`에서 `FK_DOCUMENTS_PARENT`가 존재하는지와 `DELETE_RULE = CASCADE`인지 함께 확인한다.
+17. 블록 계층 삭제 이슈를 확인할 때는 `FK_BLOCKS_DOCUMENT`, `FK_BLOCKS_PARENT`가 존재하는지와 두 FK 모두 `DELETE_RULE = CASCADE`인지 함께 확인한다.
 
 ## 확인할 로그
 

--- a/documents-api/src/test/java/com/documents/api/block/BlockControllerWebMvcTest.java
+++ b/documents-api/src/test/java/com/documents/api/block/BlockControllerWebMvcTest.java
@@ -11,6 +11,8 @@ import com.documents.api.exception.GlobalExceptionHandler;
 import com.documents.api.support.ApiResponseAssertions;
 import com.documents.domain.Block;
 import com.documents.domain.BlockType;
+import com.documents.domain.Document;
+import com.documents.domain.Workspace;
 import com.documents.exception.BusinessErrorCode;
 import com.documents.exception.BusinessException;
 import com.documents.service.BlockService;
@@ -181,8 +183,8 @@ class BlockControllerWebMvcTest {
     private Block block(UUID blockId, UUID documentId, UUID parentId, String sortKey, int version, String text) {
         Block block = Block.builder()
                 .id(blockId)
-                .documentId(documentId)
-                .parentId(parentId)
+                .document(document(documentId))
+                .parent(parentId == null ? null : parentBlock(parentId, documentId))
                 .type(BlockType.TEXT)
                 .text(text)
                 .sortKey(sortKey)
@@ -193,5 +195,27 @@ class BlockControllerWebMvcTest {
         block.setCreatedAt(LocalDateTime.of(2026, 3, 17, 0, 0));
         block.setUpdatedAt(LocalDateTime.of(2026, 3, 17, 0, 0));
         return block;
+    }
+
+    private Document document(UUID documentId) {
+        return Document.builder()
+                .id(documentId)
+                .workspace(Workspace.builder()
+                        .id(UUID.randomUUID())
+                        .name("Docs Root")
+                        .build())
+                .title("문서")
+                .sortKey("00000000000000000001")
+                .build();
+    }
+
+    private Block parentBlock(UUID blockId, UUID documentId) {
+        return Block.builder()
+                .id(blockId)
+                .document(document(documentId))
+                .type(BlockType.TEXT)
+                .text("부모 블록")
+                .sortKey("000000000001000000000000")
+                .build();
     }
 }

--- a/documents-api/src/test/java/com/documents/api/document/DocumentControllerWebMvcTest.java
+++ b/documents-api/src/test/java/com/documents/api/document/DocumentControllerWebMvcTest.java
@@ -23,6 +23,7 @@ import com.documents.api.document.support.DocumentJsonCodec;
 import com.documents.api.exception.GlobalExceptionHandler;
 import com.documents.api.support.ApiResponseAssertions;
 import com.documents.domain.Document;
+import com.documents.domain.Workspace;
 import com.documents.exception.BusinessErrorCode;
 import com.documents.exception.BusinessException;
 import com.documents.service.DocumentService;
@@ -311,8 +312,8 @@ class DocumentControllerWebMvcTest {
 	) {
 		Document document = Document.builder()
 			.id(id)
-			.workspaceId(workspaceId)
-			.parentId(parentId)
+			.workspace(workspace(workspaceId))
+			.parent(parentId == null ? null : parentDocument(parentId, workspaceId))
 			.title(title)
 			.sortKey(sortKey)
 			.iconJson(iconJson)
@@ -324,6 +325,22 @@ class DocumentControllerWebMvcTest {
 		document.setUpdatedAt(LocalDateTime.of(2026, 3, 16, 0, 0));
 		document.setVersion(version);
 		return document;
+	}
+
+	private Workspace workspace(UUID workspaceId) {
+		return Workspace.builder()
+			.id(workspaceId)
+			.name("Docs Root")
+			.build();
+	}
+
+	private Document parentDocument(UUID documentId, UUID workspaceId) {
+		return Document.builder()
+			.id(documentId)
+			.workspace(workspace(workspaceId))
+			.title("부모 문서")
+			.sortKey("00000000000000000001")
+			.build();
 	}
 
 	@Test

--- a/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
@@ -61,7 +61,7 @@ class BlockApiIntegrationTest {
                 .build());
         Block rootBlock = blockRepository.save(Block.builder()
                 .id(UUID.randomUUID())
-                .documentId(document.getId())
+                .document(document)
                 .type(BlockType.TEXT)
                 .text("루트 블록")
                 .sortKey("000000000001000000000000")
@@ -70,8 +70,8 @@ class BlockApiIntegrationTest {
                 .build());
         blockRepository.save(Block.builder()
                 .id(UUID.randomUUID())
-                .documentId(document.getId())
-                .parentId(rootBlock.getId())
+                .document(document)
+                .parent(rootBlock)
                 .type(BlockType.TEXT)
                 .text("자식 블록")
                 .sortKey("000000000001I00000000000")
@@ -80,7 +80,7 @@ class BlockApiIntegrationTest {
                 .build());
         blockRepository.save(Block.builder()
                 .id(UUID.randomUUID())
-                .documentId(document.getId())
+                .document(document)
                 .type(BlockType.TEXT)
                 .text("삭제된 블록")
                 .sortKey("000000000002000000000000")
@@ -160,7 +160,7 @@ class BlockApiIntegrationTest {
                 .build());
         Block first = blockRepository.save(Block.builder()
                 .id(UUID.randomUUID())
-                .documentId(document.getId())
+                .document(document)
                 .type(BlockType.TEXT)
                 .text("첫 블록")
                 .sortKey("000000000001000000000000")
@@ -169,7 +169,7 @@ class BlockApiIntegrationTest {
                 .build());
         Block second = blockRepository.save(Block.builder()
                 .id(UUID.randomUUID())
-                .documentId(document.getId())
+                .document(document)
                 .type(BlockType.TEXT)
                 .text("둘째 블록")
                 .sortKey("000000000002000000000000")

--- a/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
@@ -55,7 +55,7 @@ class BlockApiIntegrationTest {
                 .build());
         Document document = documentRepository.save(Document.builder()
                 .id(UUID.randomUUID())
-                .workspaceId(workspace.getId())
+                .workspace(workspace)
                 .title("문서")
                 .sortKey("00000000000000000001")
                 .build());
@@ -108,7 +108,7 @@ class BlockApiIntegrationTest {
                 .build());
         Document document = documentRepository.save(Document.builder()
                 .id(UUID.randomUUID())
-                .workspaceId(workspace.getId())
+                .workspace(workspace)
                 .title("문서")
                 .sortKey("00000000000000000001")
                 .build());
@@ -154,7 +154,7 @@ class BlockApiIntegrationTest {
                 .build());
         Document document = documentRepository.save(Document.builder()
                 .id(UUID.randomUUID())
-                .workspaceId(workspace.getId())
+                .workspace(workspace)
                 .title("문서")
                 .sortKey("00000000000000000001")
                 .build());

--- a/documents-boot/src/test/java/com/documents/api/document/DocumentApiIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/api/document/DocumentApiIntegrationTest.java
@@ -136,7 +136,7 @@ class DocumentApiIntegrationTest {
 
         Document parentDocument = documentRepository.save(Document.builder()
                 .id(UUID.randomUUID())
-                .workspaceId(otherWorkspace.getId())
+                .workspace(otherWorkspace)
                 .title("다른 워크스페이스 문서")
                 .sortKey("00000000000000000001")
                 .build());
@@ -416,8 +416,8 @@ class DocumentApiIntegrationTest {
     ) {
         return documentRepository.save(Document.builder()
                 .id(UUID.randomUUID())
-                .workspaceId(workspaceId)
-                .parentId(parentId)
+                .workspace(workspaceRepository.getReferenceById(workspaceId))
+                .parent(parentId == null ? null : documentRepository.getReferenceById(parentId))
                 .title(title)
                 .sortKey(sortKey)
                 .iconJson(iconJson)
@@ -430,7 +430,7 @@ class DocumentApiIntegrationTest {
     private Document saveDeletedDocument(UUID workspaceId, String title, String sortKey) {
         return documentRepository.save(Document.builder()
                 .id(UUID.randomUUID())
-                .workspaceId(workspaceId)
+                .workspace(workspaceRepository.getReferenceById(workspaceId))
                 .title(title)
                 .sortKey(sortKey)
                 .deletedAt(LocalDateTime.of(2026, 3, 16, 0, 0))

--- a/documents-boot/src/test/java/com/documents/schema/PersistenceSchemaIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/schema/PersistenceSchemaIntegrationTest.java
@@ -41,6 +41,14 @@ class PersistenceSchemaIntegrationTest {
         assertThat(characterMaximumLength("BLOCKS", "SORT_KEY")).isEqualTo(24);
     }
 
+    @Test
+    @DisplayName("문서 연관관계 FK는 workspace 참조와 parent cascade delete 규칙을 생성한다")
+    void documentForeignKeysUseExpectedDeleteRules() {
+        assertThat(countForeignKey("DOCUMENTS", "FK_DOCUMENTS_WORKSPACE")).isEqualTo(1);
+        assertThat(countForeignKey("DOCUMENTS", "FK_DOCUMENTS_PARENT")).isEqualTo(1);
+        assertThat(deleteRule("FK_DOCUMENTS_PARENT")).isEqualTo("CASCADE");
+    }
+
     private int countColumn(String tableName, String columnName) {
         Integer count = jdbcTemplate.queryForObject(
                 """
@@ -84,5 +92,33 @@ class PersistenceSchemaIntegrationTest {
                 columnName
         );
         return length == null ? 0 : length;
+    }
+
+    private int countForeignKey(String tableName, String constraintName) {
+        Integer count = jdbcTemplate.queryForObject(
+                """
+                        select count(*)
+                        from information_schema.table_constraints
+                        where table_name = ?
+                          and constraint_type = 'FOREIGN KEY'
+                          and constraint_name = ?
+                        """,
+                Integer.class,
+                tableName,
+                constraintName
+        );
+        return count == null ? 0 : count;
+    }
+
+    private String deleteRule(String constraintName) {
+        return jdbcTemplate.queryForObject(
+                """
+                        select delete_rule
+                        from information_schema.referential_constraints
+                        where constraint_name = ?
+                        """,
+                String.class,
+                constraintName
+        );
     }
 }

--- a/documents-boot/src/test/java/com/documents/schema/PersistenceSchemaIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/schema/PersistenceSchemaIntegrationTest.java
@@ -49,6 +49,15 @@ class PersistenceSchemaIntegrationTest {
         assertThat(deleteRule("FK_DOCUMENTS_PARENT")).isEqualTo("CASCADE");
     }
 
+    @Test
+    @DisplayName("블록 연관관계 FK는 document 참조와 parent cascade delete 규칙을 생성한다")
+    void blockForeignKeysUseExpectedDeleteRules() {
+        assertThat(countForeignKey("BLOCKS", "FK_BLOCKS_DOCUMENT")).isEqualTo(1);
+        assertThat(countForeignKey("BLOCKS", "FK_BLOCKS_PARENT")).isEqualTo(1);
+        assertThat(deleteRule("FK_BLOCKS_DOCUMENT")).isEqualTo("CASCADE");
+        assertThat(deleteRule("FK_BLOCKS_PARENT")).isEqualTo("CASCADE");
+    }
+
     private int countColumn(String tableName, String columnName) {
         Integer count = jdbcTemplate.queryForObject(
                 """

--- a/documents-core/build.gradle
+++ b/documents-core/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
     api "jakarta.persistence:jakarta.persistence-api:${rootProject.ext.resolvedJakartaPersistenceVersion}"
+    api 'org.hibernate.orm:hibernate-core'
 }

--- a/documents-core/src/main/java/com/documents/domain/Block.java
+++ b/documents-core/src/main/java/com/documents/domain/Block.java
@@ -1,20 +1,31 @@
 package com.documents.domain;
 
 import com.documents.common.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @Setter
@@ -30,11 +41,31 @@ public class Block extends BaseEntity {
     @Column(name = "block_id", nullable = false, updatable = false, columnDefinition = "char(36)")
     private UUID id;
 
-    @Column(name = "document_id", nullable = false, columnDefinition = "char(36)")
-    private UUID documentId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "document_id",
+            nullable = false,
+            columnDefinition = "char(36)",
+            foreignKey = @ForeignKey(name = "fk_blocks_document")
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ToString.Exclude
+    private Document document;
 
-    @Column(name = "parent_id", columnDefinition = "char(36)")
-    private UUID parentId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "parent_id",
+            columnDefinition = "char(36)",
+            foreignKey = @ForeignKey(name = "fk_blocks_parent")
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ToString.Exclude
+    private Block parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE)
+    @Default
+    @ToString.Exclude
+    private List<Block> children = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false, length = 32)
@@ -54,4 +85,12 @@ public class Block extends BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public UUID getDocumentId() {
+        return document == null ? null : document.getId();
+    }
+
+    public UUID getParentId() {
+        return parent == null ? null : parent.getId();
+    }
 }

--- a/documents-core/src/main/java/com/documents/domain/Document.java
+++ b/documents-core/src/main/java/com/documents/domain/Document.java
@@ -1,18 +1,29 @@
 package com.documents.domain;
 
 import com.documents.common.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @Setter
@@ -28,11 +39,30 @@ public class Document extends BaseEntity {
     @Column(name = "document_id", nullable = false, updatable = false, columnDefinition = "char(36)")
     private UUID id;
 
-    @Column(name = "workspace_id", nullable = false, columnDefinition = "char(36)")
-    private UUID workspaceId;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(
+            name = "workspace_id",
+            nullable = false,
+            columnDefinition = "char(36)",
+            foreignKey = @ForeignKey(name = "fk_documents_workspace")
+    )
+    @ToString.Exclude
+    private Workspace workspace;
 
-    @Column(name = "parent_id", columnDefinition = "char(36)")
-    private UUID parentId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "parent_id",
+            columnDefinition = "char(36)",
+            foreignKey = @ForeignKey(name = "fk_documents_parent")
+    )
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ToString.Exclude
+    private Document parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.REMOVE)
+    @Default
+    @ToString.Exclude
+    private List<Document> children = new ArrayList<>();
 
     @Column(name = "title", nullable = false, length = 255)
     private String title;
@@ -54,4 +84,12 @@ public class Document extends BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public UUID getWorkspaceId() {
+        return workspace == null ? null : workspace.getId();
+    }
+
+    public UUID getParentId() {
+        return parent == null ? null : parent.getId();
+    }
 }

--- a/documents-infrastructure/src/main/java/com/documents/repository/BlockRepository.java
+++ b/documents-infrastructure/src/main/java/com/documents/repository/BlockRepository.java
@@ -12,12 +12,18 @@ public interface BlockRepository extends JpaRepository<Block, UUID> {
 
     Optional<Block> findByIdAndDeletedAtIsNull(UUID id);
 
-    long countByDocumentIdAndDeletedAtIsNull(UUID documentId);
+    @Query("""
+            select count(b)
+            from Block b
+            where b.document.id = :documentId
+              and b.deletedAt is null
+            """)
+    long countActiveByDocumentId(@Param("documentId") UUID documentId);
 
     @Query("""
             select b
             from Block b
-            where b.documentId = :documentId
+            where b.document.id = :documentId
               and b.deletedAt is null
             order by
               b.sortKey asc,
@@ -31,10 +37,10 @@ public interface BlockRepository extends JpaRepository<Block, UUID> {
     @Query("""
             select b
             from Block b
-            where b.documentId = :documentId
+            where b.document.id = :documentId
               and (
-                (:parentId is null and b.parentId is null)
-                or b.parentId = :parentId
+                (:parentId is null and b.parent is null)
+                or b.parent.id = :parentId
               )
               and b.deletedAt is null
             order by

--- a/documents-infrastructure/src/main/java/com/documents/repository/DocumentRepository.java
+++ b/documents-infrastructure/src/main/java/com/documents/repository/DocumentRepository.java
@@ -15,10 +15,10 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
     @Query("""
             select max(d.sortKey)
             from Document d
-            where d.workspaceId = :workspaceId
+            where d.workspace.id = :workspaceId
               and (
-                (:parentId is null and d.parentId is null)
-                or d.parentId = :parentId
+                (:parentId is null and d.parent is null)
+                or d.parent.id = :parentId
               )
               and d.deletedAt is null
             """)
@@ -30,7 +30,7 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
     @Query("""
             select d
             from Document d
-            where d.workspaceId = :workspaceId
+            where d.workspace.id = :workspaceId
               and d.deletedAt is null
             order by
               d.sortKey asc,

--- a/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.documents.domain.Block;
 import com.documents.domain.BlockType;
+import com.documents.domain.Document;
 import com.documents.exception.BusinessErrorCode;
 import com.documents.exception.BusinessException;
 import com.documents.repository.BlockRepository;
@@ -49,7 +50,7 @@ public class BlockServiceImpl implements BlockService {
             UUID beforeBlockId,
             String actorId
     ) {
-        documentService.getById(documentId);
+        Document document = documentService.getById(documentId);
         validateSupportedType(type);
         validateBlockLimit(documentId);
 
@@ -66,8 +67,8 @@ public class BlockServiceImpl implements BlockService {
 
         Block newBlock = Block.builder()
                 .id(UUID.randomUUID())
-                .documentId(documentId)
-                .parentId(parentId)
+                .document(document)
+                .parent(parentBlock)
                 .type(type)
                 .text(text)
                 .sortKey(sortKey)
@@ -85,7 +86,7 @@ public class BlockServiceImpl implements BlockService {
     }
 
     private void validateBlockLimit(UUID documentId) {
-        if (blockRepository.countByDocumentIdAndDeletedAtIsNull(documentId) >= MAX_BLOCK_COUNT_PER_DOCUMENT) {
+        if (blockRepository.countActiveByDocumentId(documentId) >= MAX_BLOCK_COUNT_PER_DOCUMENT) {
             throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
         }
     }
@@ -113,8 +114,7 @@ public class BlockServiceImpl implements BlockService {
             if (depth > MAX_BLOCK_DEPTH) {
                 throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
             }
-            UUID nextParentId = current.getParentId();
-            current = nextParentId == null ? null : blockRepository.findByIdAndDeletedAtIsNull(nextParentId)
+            current = current.getParentId() == null ? null : blockRepository.findByIdAndDeletedAtIsNull(current.getParentId())
                     .orElseThrow(() -> new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND));
         }
     }

--- a/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.documents.domain.Document;
+import com.documents.domain.Workspace;
 import com.documents.exception.BusinessErrorCode;
 import com.documents.exception.BusinessException;
 import com.documents.repository.DocumentRepository;
@@ -29,16 +30,8 @@ public class DocumentServiceImpl implements DocumentService {
 	@Transactional
 	public Document create(UUID workspaceId, UUID parentId, String title, String iconJson, String coverJson,
 		String actorId) {
-		workspaceService.getById(workspaceId);
-
-		if (parentId != null) {
-			Document parentDocument = documentRepository.findByIdAndDeletedAtIsNull(parentId)
-				.orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
-
-			if (!workspaceId.equals(parentDocument.getWorkspaceId())) {
-				throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
-			}
-		}
+		Workspace workspace = workspaceService.getById(workspaceId);
+		Document parentDocument = validateParentForWorkspace(workspaceId, parentId);
 
 		String normalizedActorId = textNormalizer.normalizeNullable(actorId);
 		String normalizedTitle = textNormalizer.normalizeRequired(title);
@@ -46,8 +39,8 @@ public class DocumentServiceImpl implements DocumentService {
 
 		Document document = Document.builder()
 			.id(UUID.randomUUID())
-			.workspaceId(workspaceId)
-			.parentId(parentId)
+			.workspace(workspace)
+			.parent(parentDocument)
 			.title(normalizedTitle)
 			.iconJson(iconJson)
 			.coverJson(coverJson)
@@ -80,32 +73,44 @@ public class DocumentServiceImpl implements DocumentService {
 		Document document = documentRepository.findByIdAndDeletedAtIsNull(documentId)
 			.orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
 
-		validateParentForUpdate(document, documentId, parentId);
+		Document parentDocument = validateParentForUpdate(document, documentId, parentId);
 		applyTitle(document, title);
 		applyMetadata(document, iconJson, coverJson);
-		document.setParentId(parentId);
+		document.setParent(parentDocument);
 		document.setUpdatedBy(textNormalizer.normalizeNullable(actorId));
 
 		return document;
 	}
 
-	private void validateParentForUpdate(Document document, UUID documentId, UUID parentId) {
+	private Document validateParentForWorkspace(UUID workspaceId, UUID parentId) {
+		if (parentId == null) {
+			return null;
+		}
+
+		Document parentDocument = findActiveDocument(parentId);
+		if (!workspaceId.equals(parentDocument.getWorkspaceId())) {
+			throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+		}
+		return parentDocument;
+	}
+
+	private Document validateParentForUpdate(Document document, UUID documentId, UUID parentId) {
 		if (Objects.equals(documentId, parentId)) {
 			throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
 		}
 
 		if (parentId == null) {
-			return;
+			return null;
 		}
 
-		Document parentDocument = documentRepository.findByIdAndDeletedAtIsNull(parentId)
-			.orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
+		Document parentDocument = findActiveDocument(parentId);
 
 		if (!document.getWorkspaceId().equals(parentDocument.getWorkspaceId())) {
 			throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
 		}
 
 		validateNoCycle(documentId, parentDocument);
+		return parentDocument;
 	}
 
 	private void applyTitle(Document document, String title) {
@@ -128,14 +133,13 @@ public class DocumentServiceImpl implements DocumentService {
 				throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
 			}
 
-			UUID nextParentId = current.getParentId();
-			if (nextParentId == null) {
-				return;
-			}
-
-			current = documentRepository.findByIdAndDeletedAtIsNull(nextParentId)
-				.orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
+			current = current.getParentId() == null ? null : findActiveDocument(current.getParentId());
 		}
+	}
+
+	private Document findActiveDocument(UUID documentId) {
+		return documentRepository.findByIdAndDeletedAtIsNull(documentId)
+			.orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
 	}
 
 	private String normalizeNullableMetaJson(String value) {

--- a/documents-infrastructure/src/test/java/com/documents/service/BlockServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/BlockServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.documents.domain.Block;
 import com.documents.domain.BlockType;
 import com.documents.domain.Document;
+import com.documents.domain.Workspace;
 import com.documents.exception.BusinessErrorCode;
 import com.documents.exception.BusinessException;
 import com.documents.repository.BlockRepository;
@@ -189,7 +190,10 @@ class BlockServiceImplTest {
     private Document document(UUID documentId) {
         return Document.builder()
                 .id(documentId)
-                .workspaceId(UUID.randomUUID())
+                .workspace(Workspace.builder()
+                        .id(UUID.randomUUID())
+                        .name("Docs Root")
+                        .build())
                 .title("문서")
                 .sortKey("00000000000000000001")
                 .build();

--- a/documents-infrastructure/src/test/java/com/documents/service/BlockServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/BlockServiceImplTest.java
@@ -74,7 +74,7 @@ class BlockServiceImplTest {
     void createRootBlockAppendsToDocumentRoot() {
         UUID documentId = UUID.randomUUID();
         when(documentService.getById(documentId)).thenReturn(document(documentId));
-        when(blockRepository.countByDocumentIdAndDeletedAtIsNull(documentId)).thenReturn(0L);
+        when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(0L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, null))
                 .thenReturn(new ArrayList<>());
@@ -105,7 +105,7 @@ class BlockServiceImplTest {
         Block second = block(documentId, parentId, "000000000002000000000000");
 
         when(documentService.getById(documentId)).thenReturn(document(documentId));
-        when(blockRepository.countByDocumentIdAndDeletedAtIsNull(documentId)).thenReturn(2L);
+        when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(2L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.of(
                 block(documentId, null, "000000000001000000000000")
@@ -127,7 +127,7 @@ class BlockServiceImplTest {
         UUID parentId = UUID.randomUUID();
 
         when(documentService.getById(documentId)).thenReturn(document(documentId));
-        when(blockRepository.countByDocumentIdAndDeletedAtIsNull(documentId)).thenReturn(0L);
+        when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(0L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findByIdAndDeletedAtIsNull(parentId))
                 .thenReturn(Optional.of(block(
@@ -149,7 +149,7 @@ class BlockServiceImplTest {
         UUID documentId = UUID.randomUUID();
 
         when(documentService.getById(documentId)).thenReturn(document(documentId));
-        when(blockRepository.countByDocumentIdAndDeletedAtIsNull(documentId)).thenReturn(0L);
+        when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(0L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, null))
                 .thenReturn(new ArrayList<>());
@@ -176,7 +176,7 @@ class BlockServiceImplTest {
         UUID parentId = UUID.randomUUID();
 
         when(documentService.getById(documentId)).thenReturn(document(documentId));
-        when(blockRepository.countByDocumentIdAndDeletedAtIsNull(documentId)).thenReturn(0L);
+        when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(0L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.empty());
 
@@ -202,11 +202,21 @@ class BlockServiceImplTest {
     private Block block(UUID documentId, UUID parentId, String sortKey) {
         return Block.builder()
                 .id(UUID.randomUUID())
-                .documentId(documentId)
-                .parentId(parentId)
+                .document(document(documentId))
+                .parent(parentId == null ? null : parentBlock(parentId, documentId))
                 .type(BlockType.TEXT)
                 .text("기존 블록")
                 .sortKey(sortKey)
+                .build();
+    }
+
+    private Block parentBlock(UUID blockId, UUID documentId) {
+        return Block.builder()
+                .id(blockId)
+                .document(document(documentId))
+                .type(BlockType.TEXT)
+                .text("부모 블록")
+                .sortKey("000000000001000000000000")
                 .build();
     }
 }

--- a/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
@@ -408,8 +408,8 @@ class DocumentServiceImplTest {
     private Document document(UUID documentId, UUID workspaceId, UUID parentId, String title, String sortKey) {
         return Document.builder()
                 .id(documentId)
-                .workspaceId(workspaceId)
-                .parentId(parentId)
+                .workspace(workspace(workspaceId))
+                .parent(parentId == null ? null : parentDocument(parentId, workspaceId))
                 .title(title)
                 .sortKey(sortKey)
                 .build();

--- a/prompts/2026-03-18-block-entity-relations.md
+++ b/prompts/2026-03-18-block-entity-relations.md
@@ -1,0 +1,6 @@
+# 2026-03-18 block entity relations
+
+- 작업 목적: `Block`의 `documentId`, `parentId`를 UUID 필드가 아닌 JPA 연관관계로 전환하고 기존 API 동작을 유지한다.
+- 핵심 변경: `Block.document`/`Block.parent`/`Block.children` 매핑, `document_id`와 `parent_id` FK `ON DELETE CASCADE`, 리포지토리/서비스/테스트 픽스처를 연관관계 기준으로 정리했다.
+- 문서 반영: `docs/REQUIREMENTS.md`, `docs/runbook/DEBUG.md`, `docs/decisions/010-map-block-hierarchy-with-jpa-associations-and-db-cascade.md` 갱신.
+- 검증: `./gradlew :documents-api:test :documents-infrastructure:test :documents-boot:test --tests com.documents.api.block.BlockApiIntegrationTest --tests com.documents.schema.PersistenceSchemaIntegrationTest`

--- a/prompts/2026-03-18-document-entity-relations.md
+++ b/prompts/2026-03-18-document-entity-relations.md
@@ -1,0 +1,7 @@
+# 2026-03-18 document entity relations
+
+- 작업 목적: `Document`의 `workspaceId`, `parentId`를 UUID 필드가 아닌 JPA 연관관계로 전환하고 기존 API 동작을 유지한다.
+- 핵심 변경: `Document.workspace`/`Document.parent`/`Document.children` 매핑, `parent_id` self FK `ON DELETE CASCADE`, 서비스/리포지토리/테스트 픽스처를 연관관계 기준으로 정리했다.
+- 추가 정리: `update()`에서 부모 재조회로 인한 이중 flush/version 증가를 제거했다.
+- 문서 반영: `docs/REQUIREMENTS.md`, `docs/runbook/DEBUG.md`, `docs/decisions/009-map-document-hierarchy-with-jpa-associations-and-db-cascade.md` 갱신.
+- 검증: `./gradlew :documents-api:test :documents-infrastructure:test :documents-boot:test --tests com.documents.api.document.DocumentApiIntegrationTest --tests com.documents.api.block.BlockApiIntegrationTest --tests com.documents.schema.PersistenceSchemaIntegrationTest`


### PR DESCRIPTION
<!--
제목 작성 요령
[${CONVENTION}] ${구현 내용 요약}

CONVENTION 예시
- [FEAT]  : 새로운 기능 추가
- [FIX]   : 버그 수정
- [REFACTOR] : 코드 리팩터링 (기능 변화 X)
- [CHORE] : 빌드/설정/환경 변경
- [DOCS]  : 문서 수정
-->

## 📝 Part (해당되는 것만 체크)

- [x] BE
- [ ] FE
- [ ] Infra
- [x] Docs
- [x] Test

---

## #️⃣ 연관된 이슈

<!--
이슈와 PR를 자동으로 연결하기 위한 영역입니다.
예시:
- closes #17
- fixes #24
여러 개일 경우 쉼표로 구분해서 적어주세요.
-->

closes #17 

---

## 🔎 작업 내용

<!--
무슨 일을 했는지 "한 눈에" 이해할 수 있게 적어주세요.
가능하면 bullet 형식으로 요약해 주세요.
-->

### 1. 주요 변경 사항 요약

- `Document` , `Block` 엔티티에 연관관계 매핑 적용
- 연관관계 매핑 기준으로, 기존 조회/생성/검증 로직 리팩토링
  - 외부 API 계약과 기존 기능 동작은 유지
- 연관관계 및 cascade delete 설정 검증 테스트 추가

### 2. 상세 내용 (선택)

- 기존에는 `Document` , `Block` 엔티티가 연관 대상을 **UUID** 필드로만 보관하고 있었습니다.
  - 이번 변경에서는 **JPA 엔티티 모델**이 관계를 직접 표현하도록 `@ManyToOne` 기반 연관관계를 적용했습니다.
  - **외부 API 요청/응답**은 기존처럼 `workspaceId` , `documentId` , `parentId` 를 유지하고, 내부 영속 모델과 서비스 로직만 연관관계 중심으로 정리했습니다.
  - `@OnDelete` 를 적용하여, **DB Level의 hard delete** 상황에서도 하위 데이터가 함께 정리되도록 했습니다.
  - **Application Level**에서는 기존과 동일하게, 연관 관계 검증, 계층 검증, 조회/생성 기능이 동작하도록 리팩토링했습니다.

### 3. 프롬프트 경로

- [/prompts/2026-03-18-document-entity-relations.md](https://github.com/jho951/Block-server/blob/bc7e71f460c09716220cd66658e8ff233bea4ab9/prompts/2026-03-18-document-entity-relations.md)
- [/prompts/2026-03-18-block-entity-relations.md](https://github.com/jho951/Block-server/blob/a7bd10d427d70cdd381b7ec2acd02c995c41830f/prompts/2026-03-18-block-entity-relations.md)

### 4. ADR 경로 (선택)

- [/docs/decisions/009-map-document-hierarchy-with-jpa-associations-and-db-cascade.md](https://github.com/jho951/Block-server/blob/bc7e71f460c09716220cd66658e8ff233bea4ab9/docs/decisions/009-map-document-hierarchy-with-jpa-associations-and-db-cascade.md)
- [/docs/decisions/010-map-block-hierarchy-with-jpa-associations-and-db-cascade.md](https://github.com/jho951/Block-server/blob/a7bd10d427d70cdd381b7ec2acd02c995c41830f/docs/decisions/010-map-block-hierarchy-with-jpa-associations-and-db-cascade.md)

---

## 💬 집중 리뷰 요청

<!--
리뷰어가 어디를 중점적으로 봐야 하는지 알려주세요.
복잡한 로직, 트레이드오프, 고민했던 포인트를 적어주면 리뷰 품질이 올라갑니다.
-->

- 변경된 엔티티 구조와 기존 구현하신 서비스 로직이 어떻게 변경되었는지를 집중적으로 봐주세요.
- 성능의 경우, 당장은 고려하지 않았습니다. 따라서, `@OneToMany` 를 당장은 사용하는  방향으로 설계했습니다.

---

## 🧪 테스트 방법

<!--
리뷰어/테스터가 동일하게 재현할 수 있도록, 테스트 방법을 구체적으로 적어주세요.
로컬/스테이징 환경 기준, 실행 커맨드가 있으면 함께 작성해 주세요.
-->

### 1. 로컬 실행 방법

- documents-api 테스트: Controller slice 테스트, 요청/응답 직렬화, @Valid 검증, 공통 예외 응답 검증을 위한 빠른 테스트
  - `./gradlew :documents-api:test`
- documents-infrastructure 테스트: JPA 저장소, 커스텀 쿼리, 영속 구현 검증 테스트와 서비스 구현의 빠른 단위 테스트
  - `./gradlew :documents-infrastructure:test`
- documents-boot 테스트: API 통합 테스트(Controller + Spring MVC + Service + Repository + DB)
  - `./gradlew :documents-boot:test`

### 2. 테스트 시나리오

_No response_

---

## ✅ PR 체크리스트

<!--
PR 올리기 전에 스스로 한 번 더 점검하는 용도입니다.
팀 컨벤션에 맞게 자유롭게 수정해서 사용하세요.
-->

- [x] 불필요한 디버그 로그 / 주석 제거
- [x] breaking change 여부 확인 및 문서화
- [x] 신규/변경된 기능에 대한 테스트 코드 추가 또는 기존 테스트 통과
- [ ] 로컬에서 주요 시나리오 수동 테스트 완료
- [x] 관련 문서(노션, README, API 문서 등) 업데이트

---

## 📈 이미지 / 캡처 (필요 시)

<!--
UI 변경, 에러 화면, API 응답 예시 등이 있다면 이미지로 첨부해주세요.
-->

_No response_