### PR TITLE
feat: 문서(Document) 삭제 API 구현

### DIFF
--- a/documents-api/src/main/java/com/documents/api/document/DocumentController.java
+++ b/documents-api/src/main/java/com/documents/api/document/DocumentController.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -94,5 +95,15 @@ public class DocumentController {
                 userId
         );
         return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, documentApiMapper.toResponse(updatedDocument)));
+    }
+
+    @Operation(summary = "문서 삭제")
+    @DeleteMapping("/documents/{documentId}")
+    public ResponseEntity<GlobalResponse<Void>> deleteDocument(
+            @PathVariable("documentId") UUID documentId,
+            @RequestHeader(USER_ID_HEADER) String userId
+    ) {
+        documentService.delete(documentId, userId);
+        return ResponseEntity.ok(GlobalResponse.ok());
     }
 }

--- a/documents-api/src/test/java/com/documents/api/document/DocumentControllerWebMvcTest.java
+++ b/documents-api/src/test/java/com/documents/api/document/DocumentControllerWebMvcTest.java
@@ -33,10 +33,68 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @DisplayName("Document 컨트롤러 빠른 검증")
 class DocumentControllerWebMvcTest {
 
+	private static final String USER_ID_HEADER = "X-User-Id";
+	private static final String ACTOR_ID = "user-123";
+	private static final String ROOT_WORKSPACE_NAME = "Docs Root";
+	private static final String PROJECT_OVERVIEW_TITLE = "프로젝트 개요";
+	private static final String UPDATED_PROJECT_OVERVIEW_TITLE = "수정된 프로젝트 개요";
+	private static final String ROOT_DOCUMENT_TITLE = "루트 문서";
+	private static final String CHILD_DOCUMENT_TITLE = "하위 문서";
+	private static final String PARENT_DOCUMENT_TITLE = "부모 문서";
+	private static final String ICON_DOC_JSON = "{\"type\":\"emoji\",\"value\":\"📄\"}";
+	private static final String ICON_SMILE_JSON = "{\"type\":\"emoji\",\"value\":\"😀\"}";
+	private static final String COVER_1_JSON = "{\"type\":\"image\",\"value\":\"cover-1\"}";
+	private static final String COVER_2_JSON = "{\"type\":\"image\",\"value\":\"cover-2\"}";
+	private static final LocalDateTime FIXTURE_TIME = LocalDateTime.of(2026, 3, 16, 0, 0);
+
 	@Mock
 	private DocumentService documentService;
 
 	private MockMvc mockMvc;
+
+	private Document document(
+		UUID id,
+		UUID workspaceId,
+		UUID parentId,
+		String title,
+		String actorId,
+		Integer version,
+		String sortKey,
+		String iconJson,
+		String coverJson
+	) {
+		Document document = Document.builder()
+			.id(id)
+			.workspace(workspace(workspaceId))
+			.parent(parentId == null ? null : parentDocument(parentId, workspaceId))
+			.title(title)
+			.sortKey(sortKey)
+			.iconJson(iconJson)
+			.coverJson(coverJson)
+			.createdBy(actorId)
+			.updatedBy(actorId)
+			.build();
+		document.setCreatedAt(FIXTURE_TIME);
+		document.setUpdatedAt(FIXTURE_TIME);
+		document.setVersion(version);
+		return document;
+	}
+
+	private Workspace workspace(UUID workspaceId) {
+		return Workspace.builder()
+			.id(workspaceId)
+			.name(ROOT_WORKSPACE_NAME)
+			.build();
+	}
+
+	private Document parentDocument(UUID documentId, UUID workspaceId) {
+		return Document.builder()
+			.id(documentId)
+			.workspace(workspace(workspaceId))
+			.title(PARENT_DOCUMENT_TITLE)
+			.sortKey("00000000000000000001")
+			.build();
+	}
 
 	@BeforeEach
 	void setUp() {
@@ -62,18 +120,18 @@ class DocumentControllerWebMvcTest {
 		when(documentService.create(
 			eq(workspaceId),
 			eq(parentId),
-			eq("프로젝트 개요"),
-			eq("{\"type\":\"emoji\",\"value\":\"📄\"}"),
-			eq("{\"type\":\"image\",\"value\":\"cover-1\"}"),
-			eq("user-123")
-		)).thenReturn(document(documentId, workspaceId, parentId, "프로젝트 개요", "user-123", 0,
+			eq(PROJECT_OVERVIEW_TITLE),
+			eq(ICON_DOC_JSON),
+			eq(COVER_1_JSON),
+			eq(ACTOR_ID)
+		)).thenReturn(document(documentId, workspaceId, parentId, PROJECT_OVERVIEW_TITLE, ACTOR_ID, 0,
 			"00000000000000000003",
-			"{\"type\":\"emoji\",\"value\":\"📄\"}",
-			"{\"type\":\"image\",\"value\":\"cover-1\"}"));
+			ICON_DOC_JSON,
+			COVER_1_JSON));
 
 		mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspaceId)
 				.contentType("application/json")
-				.header("X-User-Id", "user-123")
+				.header(USER_ID_HEADER, ACTOR_ID)
 				.content("""
 					{
 					  "parentId": "%s",
@@ -96,11 +154,11 @@ class DocumentControllerWebMvcTest {
 			.andExpect(jsonPath("$.data.id").value(documentId.toString()))
 			.andExpect(jsonPath("$.data.workspaceId").value(workspaceId.toString()))
 			.andExpect(jsonPath("$.data.parentId").value(parentId.toString()))
-			.andExpect(jsonPath("$.data.title").value("프로젝트 개요"))
+			.andExpect(jsonPath("$.data.title").value(PROJECT_OVERVIEW_TITLE))
 			.andExpect(jsonPath("$.data.sortKey").value("00000000000000000003"))
 			.andExpect(jsonPath("$.data.icon.type").value("emoji"))
 			.andExpect(jsonPath("$.data.cover.value").value("cover-1"))
-			.andExpect(jsonPath("$.data.createdBy").value("user-123"));
+			.andExpect(jsonPath("$.data.createdBy").value(ACTOR_ID));
 	}
 
 	@Test
@@ -111,9 +169,9 @@ class DocumentControllerWebMvcTest {
 		UUID childDocumentId = UUID.randomUUID();
 
 		when(documentService.getAllByWorkspaceId(workspaceId)).thenReturn(List.of(
-			document(rootDocumentId, workspaceId, null, "루트 문서", "user-123", 0,
+			document(rootDocumentId, workspaceId, null, ROOT_DOCUMENT_TITLE, ACTOR_ID, 0,
 				"00000000000000000001", null, null),
-			document(childDocumentId, workspaceId, rootDocumentId, "하위 문서", "user-123", 1,
+			document(childDocumentId, workspaceId, rootDocumentId, CHILD_DOCUMENT_TITLE, ACTOR_ID, 1,
 				"00000000000000000002", null, null)
 		));
 
@@ -124,7 +182,7 @@ class DocumentControllerWebMvcTest {
 			.andExpect(jsonPath("$.code").value(200))
 			.andExpect(jsonPath("$.data[0].id").value(rootDocumentId.toString()))
 			.andExpect(jsonPath("$.data[0].parentId").doesNotExist())
-			.andExpect(jsonPath("$.data[0].title").value("루트 문서"))
+			.andExpect(jsonPath("$.data[0].title").value(ROOT_DOCUMENT_TITLE))
 			.andExpect(jsonPath("$.data[0].sortKey").value("00000000000000000001"))
 			.andExpect(jsonPath("$.data[1].id").value(childDocumentId.toString()))
 			.andExpect(jsonPath("$.data[1].parentId").value(rootDocumentId.toString()))
@@ -149,7 +207,7 @@ class DocumentControllerWebMvcTest {
 	void createDocumentRejectsBlankTitle() throws Exception {
 		var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", UUID.randomUUID())
 			.contentType("application/json")
-			.header("X-User-Id", "user-123")
+			.header(USER_ID_HEADER, ACTOR_ID)
 			.content("""
 				{
 				  "title": " "
@@ -167,15 +225,15 @@ class DocumentControllerWebMvcTest {
 		when(documentService.create(
 			eq(workspaceId),
 			eq(UUID.fromString("11111111-1111-1111-1111-111111111111")),
-			eq("프로젝트 개요"),
+			eq(PROJECT_OVERVIEW_TITLE),
 			eq(null),
 			eq(null),
-			eq("user-123")
+			eq(ACTOR_ID)
 		)).thenThrow(new BusinessException(BusinessErrorCode.INVALID_REQUEST));
 
 		var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspaceId)
 			.contentType("application/json")
-			.header("X-User-Id", "user-123")
+			.header(USER_ID_HEADER, ACTOR_ID)
 			.content("""
 				{
 				  "parentId": "11111111-1111-1111-1111-111111111111",
@@ -195,15 +253,15 @@ class DocumentControllerWebMvcTest {
 		when(documentService.create(
 			eq(workspaceId),
 			eq(parentId),
-			eq("프로젝트 개요"),
+			eq(PROJECT_OVERVIEW_TITLE),
 			eq(null),
 			eq(null),
-			eq("user-123")
+			eq(ACTOR_ID)
 		)).thenThrow(new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
 
 		var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspaceId)
 			.contentType("application/json")
-			.header("X-User-Id", "user-123")
+			.header(USER_ID_HEADER, ACTOR_ID)
 			.content("""
 				{
 				  "parentId": "11111111-1111-1111-1111-111111111111",
@@ -221,9 +279,9 @@ class DocumentControllerWebMvcTest {
 		UUID documentId = UUID.randomUUID();
 
 		when(documentService.getById(documentId))
-			.thenReturn(document(documentId, workspaceId, null, "프로젝트 개요", "user-123", 2,
+			.thenReturn(document(documentId, workspaceId, null, PROJECT_OVERVIEW_TITLE, ACTOR_ID, 2,
 				"00000000000000000007",
-				"{\"type\":\"emoji\",\"value\":\"📄\"}",
+				ICON_DOC_JSON,
 				null));
 
 		mockMvc.perform(get("/v1/documents/{documentId}", documentId))
@@ -233,7 +291,7 @@ class DocumentControllerWebMvcTest {
 			.andExpect(jsonPath("$.code").value(200))
 			.andExpect(jsonPath("$.data.id").value(documentId.toString()))
 			.andExpect(jsonPath("$.data.workspaceId").value(workspaceId.toString()))
-			.andExpect(jsonPath("$.data.title").value("프로젝트 개요"))
+			.andExpect(jsonPath("$.data.title").value(PROJECT_OVERVIEW_TITLE))
 			.andExpect(jsonPath("$.data.sortKey").value("00000000000000000007"))
 			.andExpect(jsonPath("$.data.icon.value").value("📄"))
 			.andExpect(jsonPath("$.data.version").value(2));
@@ -299,50 +357,6 @@ class DocumentControllerWebMvcTest {
 		ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
 	}
 
-	private Document document(
-		UUID id,
-		UUID workspaceId,
-		UUID parentId,
-		String title,
-		String actorId,
-		Integer version,
-		String sortKey,
-		String iconJson,
-		String coverJson
-	) {
-		Document document = Document.builder()
-			.id(id)
-			.workspace(workspace(workspaceId))
-			.parent(parentId == null ? null : parentDocument(parentId, workspaceId))
-			.title(title)
-			.sortKey(sortKey)
-			.iconJson(iconJson)
-			.coverJson(coverJson)
-			.createdBy(actorId)
-			.updatedBy(actorId)
-			.build();
-		document.setCreatedAt(LocalDateTime.of(2026, 3, 16, 0, 0));
-		document.setUpdatedAt(LocalDateTime.of(2026, 3, 16, 0, 0));
-		document.setVersion(version);
-		return document;
-	}
-
-	private Workspace workspace(UUID workspaceId) {
-		return Workspace.builder()
-			.id(workspaceId)
-			.name("Docs Root")
-			.build();
-	}
-
-	private Document parentDocument(UUID documentId, UUID workspaceId) {
-		return Document.builder()
-			.id(documentId)
-			.workspace(workspace(workspaceId))
-			.title("부모 문서")
-			.sortKey("00000000000000000001")
-			.build();
-	}
-
 	@Test
 	@DisplayName("성공_문서 수정 요청에 대해 수정 응답을 반환한다")
 	void updateDocumentReturnsEnvelope() throws Exception {
@@ -352,19 +366,19 @@ class DocumentControllerWebMvcTest {
 
 		when(documentService.update(
 			eq(documentId),
-			eq("수정된 프로젝트 개요"),
-			eq("{\"type\":\"emoji\",\"value\":\"📄\"}"),
-			eq("{\"type\":\"image\",\"value\":\"cover-2\"}"),
+			eq(UPDATED_PROJECT_OVERVIEW_TITLE),
+			eq(ICON_DOC_JSON),
+			eq(COVER_2_JSON),
 			eq(parentId),
-			eq("user-123")
-		)).thenReturn(document(documentId, workspaceId, parentId, "수정된 프로젝트 개요", "user-123", 3,
+			eq(ACTOR_ID)
+		)).thenReturn(document(documentId, workspaceId, parentId, UPDATED_PROJECT_OVERVIEW_TITLE, ACTOR_ID, 3,
 			"00000000000000000007",
-			"{\"type\":\"emoji\",\"value\":\"📄\"}",
-			"{\"type\":\"image\",\"value\":\"cover-2\"}"));
+			ICON_DOC_JSON,
+			COVER_2_JSON));
 
 		mockMvc.perform(patch("/v1/documents/{documentId}", documentId)
 				.contentType("application/json")
-				.header("X-User-Id", "user-123")
+				.header(USER_ID_HEADER, ACTOR_ID)
 				.content("""
 					{
 					  "title": "수정된 프로젝트 개요",
@@ -386,7 +400,7 @@ class DocumentControllerWebMvcTest {
 			.andExpect(jsonPath("$.message").value("요청 응답 성공"))
 			.andExpect(jsonPath("$.data.id").value(documentId.toString()))
 			.andExpect(jsonPath("$.data.parentId").value(parentId.toString()))
-			.andExpect(jsonPath("$.data.title").value("수정된 프로젝트 개요"))
+			.andExpect(jsonPath("$.data.title").value(UPDATED_PROJECT_OVERVIEW_TITLE))
 			.andExpect(jsonPath("$.data.cover.value").value("cover-2"))
 			.andExpect(jsonPath("$.data.version").value(3));
 	}
@@ -398,16 +412,16 @@ class DocumentControllerWebMvcTest {
 
 		when(documentService.update(
 			eq(documentId),
-			eq("수정된 프로젝트 개요"),
+			eq(UPDATED_PROJECT_OVERVIEW_TITLE),
 			eq(null),
 			eq(null),
 			eq(null),
-			eq("user-123")
+			eq(ACTOR_ID)
 		)).thenThrow(new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
 
 		var result = mockMvc.perform(patch("/v1/documents/{documentId}", documentId)
 			.contentType("application/json")
-			.header("X-User-Id", "user-123")
+			.header(USER_ID_HEADER, ACTOR_ID)
 			.content("""
 				{
 				  "title": "수정된 프로젝트 개요"
@@ -424,16 +438,16 @@ class DocumentControllerWebMvcTest {
 
 		when(documentService.update(
 			eq(documentId),
-			eq("수정된 프로젝트 개요"),
+			eq(UPDATED_PROJECT_OVERVIEW_TITLE),
 			eq(null),
 			eq(null),
 			eq(documentId),
-			eq("user-123")
+			eq(ACTOR_ID)
 		)).thenThrow(new BusinessException(BusinessErrorCode.INVALID_REQUEST));
 
 		var result = mockMvc.perform(patch("/v1/documents/{documentId}", documentId)
 			.contentType("application/json")
-			.header("X-User-Id", "user-123")
+			.header(USER_ID_HEADER, ACTOR_ID)
 			.content("""
 				{
 				  "title": "수정된 프로젝트 개요",
@@ -452,16 +466,16 @@ class DocumentControllerWebMvcTest {
 
 		when(documentService.update(
 			eq(documentId),
-			eq("수정된 프로젝트 개요"),
+			eq(UPDATED_PROJECT_OVERVIEW_TITLE),
 			eq(null),
 			eq(null),
 			eq(parentId),
-			eq("user-123")
+			eq(ACTOR_ID)
 		)).thenThrow(new BusinessException(BusinessErrorCode.INVALID_REQUEST));
 
 		var result = mockMvc.perform(patch("/v1/documents/{documentId}", documentId)
 			.contentType("application/json")
-			.header("X-User-Id", "user-123")
+			.header(USER_ID_HEADER, ACTOR_ID)
 			.content("""
 				{
 				  "title": "수정된 프로젝트 개요",
@@ -479,7 +493,7 @@ class DocumentControllerWebMvcTest {
 
 		var result = mockMvc.perform(patch("/v1/documents/{documentId}", documentId)
 			.contentType("application/json")
-			.header("X-User-Id", "user-123")
+			.header(USER_ID_HEADER, ACTOR_ID)
 			.content("""
 				{
 				  "parentId": null
@@ -524,4 +538,57 @@ class DocumentControllerWebMvcTest {
 		ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
 	}
 
+	@Test
+	@DisplayName("성공_정상 삭제 요청 시 성공 응답을 반환한다")
+	void deleteDocumentReturnsSuccessEnvelope() throws Exception {
+		UUID documentId = UUID.randomUUID();
+		doNothing().when(documentService).delete(documentId, ACTOR_ID);
+
+		mockMvc.perform(delete("/v1/documents/{documentId}", documentId)
+				.header(USER_ID_HEADER, ACTOR_ID))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.httpStatus").value("OK"))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청 응답 성공"))
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.data").doesNotExist());
+
+		verify(documentService).delete(documentId, ACTOR_ID);
+	}
+
+	@Test
+	@DisplayName("실패_존재하지 않는 문서 삭제 시 문서 없음 응답을 반환한다")
+	void deleteDocumentReturnsNotFoundWhenDocumentMissing() throws Exception {
+		UUID documentId = UUID.randomUUID();
+		doThrow(new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND))
+			.when(documentService).delete(documentId, ACTOR_ID);
+
+		var result = mockMvc.perform(delete("/v1/documents/{documentId}", documentId)
+			.header(USER_ID_HEADER, ACTOR_ID));
+
+		ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_이미 soft delete된 문서 삭제 시 문서 없음 응답을 반환한다")
+	void deleteDocumentReturnsNotFoundWhenDocumentAlreadyDeleted() throws Exception {
+		UUID documentId = UUID.randomUUID();
+		doThrow(new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND))
+			.when(documentService).delete(documentId, ACTOR_ID);
+
+		var result = mockMvc.perform(delete("/v1/documents/{documentId}", documentId)
+			.header(USER_ID_HEADER, ACTOR_ID));
+
+		ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_X-User-Id 헤더가 없으면 인증 오류를 반환한다")
+	void deleteDocumentReturnsUnauthorizedWhenHeaderMissing() throws Exception {
+		UUID documentId = UUID.randomUUID();
+
+		var result = mockMvc.perform(delete("/v1/documents/{documentId}", documentId));
+
+		ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
+	}
 }

--- a/documents-boot/src/test/java/com/documents/api/document/DocumentApiIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/api/document/DocumentApiIntegrationTest.java
@@ -5,14 +5,21 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
+import java.util.Locale;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import org.hibernate.resource.jdbc.spi.StatementInspector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -26,6 +33,7 @@ import com.documents.repository.WorkspaceRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Import(DocumentApiIntegrationTest.DocumentDeleteSqlCounterTestConfig.class)
 @DisplayName("Document API 통합 검증")
 class DocumentApiIntegrationTest {
 
@@ -41,11 +49,15 @@ class DocumentApiIntegrationTest {
     @Autowired
     private BlockRepository blockRepository;
 
+    @Autowired
+    private DocumentDeleteSqlCounter documentDeleteSqlCounter;
+
     @BeforeEach
     void setUp() {
         blockRepository.deleteAll();
         documentRepository.deleteAll();
         workspaceRepository.deleteAll();
+        documentDeleteSqlCounter.reset();
     }
 
     @Test
@@ -392,15 +404,18 @@ class DocumentApiIntegrationTest {
     }
 
     @Test
-    @DisplayName("성공_문서 삭제 API는 문서와 해당 문서의 활성 블록만 soft delete 처리한다")
-    void deleteDocumentSoftDeletesDocumentAndOwnBlocksOnly() throws Exception {
+    @DisplayName("성공_문서 삭제 API는 하위 문서와 각 문서의 활성 블록까지 soft delete 처리한다")
+    void deleteDocumentSoftDeletesDescendantDocumentsAndBlocks() throws Exception {
         Workspace workspace = workspace("Docs Root");
         Document targetDocument = saveDocument(workspace.getId(), null, "삭제 대상 문서", "00000000000000000001");
+        Document childDocument = saveDocument(workspace.getId(), targetDocument.getId(), "하위 문서", "00000000000000000002");
         Document otherDocument = saveDocument(workspace.getId(), null, "다른 문서", "00000000000000000002");
 
         Block targetRootBlock = saveBlock(targetDocument.getId(), null, "대상 루트 블록", "000000000001000000000000");
         Block targetChildBlock = saveBlock(targetDocument.getId(), targetRootBlock.getId(), "대상 자식 블록", "000000000001I00000000000");
+        Block childDocumentBlock = saveBlock(childDocument.getId(), null, "하위 문서 블록", "000000000001000000000000");
         Block otherDocumentBlock = saveBlock(otherDocument.getId(), null, "다른 문서 블록", "000000000001000000000000");
+        documentDeleteSqlCounter.reset();
 
         mockMvc.perform(delete("/v1/documents/{documentId}", targetDocument.getId())
                         .header("X-User-Id", "user-123"))
@@ -410,15 +425,20 @@ class DocumentApiIntegrationTest {
                 .andExpect(jsonPath("$.code").value(200));
 
         Document deletedDocument = documentRepository.findById(targetDocument.getId()).orElseThrow();
+        Document deletedChildDocument = documentRepository.findById(childDocument.getId()).orElseThrow();
         assertThat(deletedDocument.getDeletedAt()).isNotNull();
+        assertThat(deletedChildDocument.getDeletedAt()).isNotNull();
 
         Block deletedRootBlock = blockRepository.findById(targetRootBlock.getId()).orElseThrow();
         Block deletedChildBlock = blockRepository.findById(targetChildBlock.getId()).orElseThrow();
+        Block deletedDescendantDocumentBlock = blockRepository.findById(childDocumentBlock.getId()).orElseThrow();
         Block survivedOtherBlock = blockRepository.findById(otherDocumentBlock.getId()).orElseThrow();
 
         assertThat(deletedRootBlock.getDeletedAt()).isNotNull();
         assertThat(deletedChildBlock.getDeletedAt()).isNotNull();
+        assertThat(deletedDescendantDocumentBlock.getDeletedAt()).isNotNull();
         assertThat(survivedOtherBlock.getDeletedAt()).isNull();
+        assertThat(documentDeleteSqlCounter.documentSoftDeleteUpdateCount()).isEqualTo(1);
     }
 
     @Test
@@ -510,5 +530,41 @@ class DocumentApiIntegrationTest {
                 .createdBy("user-123")
                 .updatedBy("user-123")
                 .build());
+    }
+
+    @TestConfiguration
+    static class DocumentDeleteSqlCounterTestConfig {
+
+        @Bean
+        DocumentDeleteSqlCounter documentDeleteSqlCounter() {
+            return new DocumentDeleteSqlCounter();
+        }
+
+        @Bean
+        HibernatePropertiesCustomizer documentDeleteSqlCounterCustomizer(DocumentDeleteSqlCounter counter) {
+            return properties -> properties.put("hibernate.session_factory.statement_inspector", counter);
+        }
+    }
+
+    static class DocumentDeleteSqlCounter implements StatementInspector {
+
+        private final AtomicInteger documentSoftDeleteUpdateCount = new AtomicInteger();
+
+        @Override
+        public String inspect(String sql) {
+            String normalizedSql = sql.toLowerCase(Locale.ROOT);
+            if (normalizedSql.contains("update documents") && normalizedSql.contains("deleted_at")) {
+                documentSoftDeleteUpdateCount.incrementAndGet();
+            }
+            return sql;
+        }
+
+        void reset() {
+            documentSoftDeleteUpdateCount.set(0);
+        }
+
+        int documentSoftDeleteUpdateCount() {
+            return documentSoftDeleteUpdateCount.get();
+        }
     }
 }

--- a/documents-boot/src/test/java/com/documents/api/document/DocumentApiIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/api/document/DocumentApiIntegrationTest.java
@@ -17,7 +17,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 import com.documents.domain.Document;
+import com.documents.domain.Block;
+import com.documents.domain.BlockType;
 import com.documents.domain.Workspace;
+import com.documents.repository.BlockRepository;
 import com.documents.repository.DocumentRepository;
 import com.documents.repository.WorkspaceRepository;
 
@@ -35,8 +38,12 @@ class DocumentApiIntegrationTest {
     @Autowired
     private DocumentRepository documentRepository;
 
+    @Autowired
+    private BlockRepository blockRepository;
+
     @BeforeEach
     void setUp() {
+        blockRepository.deleteAll();
         documentRepository.deleteAll();
         workspaceRepository.deleteAll();
     }
@@ -384,6 +391,61 @@ class DocumentApiIntegrationTest {
         assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
     }
 
+    @Test
+    @DisplayName("성공_문서 삭제 API는 문서와 해당 문서의 활성 블록만 soft delete 처리한다")
+    void deleteDocumentSoftDeletesDocumentAndOwnBlocksOnly() throws Exception {
+        Workspace workspace = workspace("Docs Root");
+        Document targetDocument = saveDocument(workspace.getId(), null, "삭제 대상 문서", "00000000000000000001");
+        Document otherDocument = saveDocument(workspace.getId(), null, "다른 문서", "00000000000000000002");
+
+        Block targetRootBlock = saveBlock(targetDocument.getId(), null, "대상 루트 블록", "000000000001000000000000");
+        Block targetChildBlock = saveBlock(targetDocument.getId(), targetRootBlock.getId(), "대상 자식 블록", "000000000001I00000000000");
+        Block otherDocumentBlock = saveBlock(otherDocument.getId(), null, "다른 문서 블록", "000000000001000000000000");
+
+        mockMvc.perform(delete("/v1/documents/{documentId}", targetDocument.getId())
+                        .header("X-User-Id", "user-123"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(200));
+
+        Document deletedDocument = documentRepository.findById(targetDocument.getId()).orElseThrow();
+        assertThat(deletedDocument.getDeletedAt()).isNotNull();
+
+        Block deletedRootBlock = blockRepository.findById(targetRootBlock.getId()).orElseThrow();
+        Block deletedChildBlock = blockRepository.findById(targetChildBlock.getId()).orElseThrow();
+        Block survivedOtherBlock = blockRepository.findById(otherDocumentBlock.getId()).orElseThrow();
+
+        assertThat(deletedRootBlock.getDeletedAt()).isNotNull();
+        assertThat(deletedChildBlock.getDeletedAt()).isNotNull();
+        assertThat(survivedOtherBlock.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("성공_문서 삭제 후 같은 문서를 단건 조회하면 문서 없음 응답을 반환한다")
+    void getDocumentReturnsNotFoundAfterDelete() throws Exception {
+        Workspace workspace = workspace("Docs Root");
+        Document document = saveDocument(workspace.getId(), null, "삭제 대상 문서", "00000000000000000001");
+        saveBlock(document.getId(), null, "대상 블록", "000000000001000000000000");
+
+        mockMvc.perform(delete("/v1/documents/{documentId}", document.getId())
+                        .header("X-User-Id", "user-123"))
+                .andExpect(status().isOk());
+
+        var result = mockMvc.perform(get("/v1/documents/{documentId}", document.getId()));
+
+        assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("실패_존재하지 않는 문서를 삭제하면 문서 없음 응답을 반환한다")
+    void deleteDocumentReturnsNotFoundWhenDocumentMissing() throws Exception {
+        var result = mockMvc.perform(delete("/v1/documents/{documentId}", UUID.randomUUID())
+                        .header("X-User-Id", "user-123"));
+
+        assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+    }
+
     private void assertErrorEnvelope(ResultActions result, String httpStatus, int code, String message) throws Exception {
         result.andExpect(status().is(org.springframework.http.HttpStatus.valueOf(httpStatus).value()))
                 .andExpect(jsonPath("$.httpStatus").value(httpStatus))
@@ -434,6 +496,19 @@ class DocumentApiIntegrationTest {
                 .title(title)
                 .sortKey(sortKey)
                 .deletedAt(LocalDateTime.of(2026, 3, 16, 0, 0))
+                .build());
+    }
+
+    private Block saveBlock(UUID documentId, UUID parentId, String text, String sortKey) {
+        return blockRepository.save(Block.builder()
+                .id(UUID.randomUUID())
+                .document(documentRepository.getReferenceById(documentId))
+                .parent(parentId == null ? null : blockRepository.getReferenceById(parentId))
+                .type(BlockType.TEXT)
+                .text(text)
+                .sortKey(sortKey)
+                .createdBy("user-123")
+                .updatedBy("user-123")
                 .build());
     }
 }

--- a/documents-core/src/main/java/com/documents/service/BlockService.java
+++ b/documents-core/src/main/java/com/documents/service/BlockService.java
@@ -2,6 +2,7 @@ package com.documents.service;
 
 import com.documents.domain.Block;
 import com.documents.domain.BlockType;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,4 +20,6 @@ public interface BlockService {
     );
 
     Block update(UUID blockId, String text, Integer version, String actorId);
+
+    void softDeleteAllByDocumentId(UUID documentId, String actorId, LocalDateTime deletedAt);
 }

--- a/documents-core/src/main/java/com/documents/service/DocumentService.java
+++ b/documents-core/src/main/java/com/documents/service/DocumentService.java
@@ -9,4 +9,5 @@ public interface DocumentService {
     List<Document> getAllByWorkspaceId(UUID workspaceId);
     Document getById(UUID documentId);
     Document update(UUID documentId, String title, String iconJson, String coverJson, UUID parentId, String actorId);
+    void delete(UUID documentId, String actorId);
 }

--- a/documents-infrastructure/src/main/java/com/documents/repository/BlockRepository.java
+++ b/documents-infrastructure/src/main/java/com/documents/repository/BlockRepository.java
@@ -3,8 +3,10 @@ package com.documents.repository;
 import com.documents.domain.Block;
 import java.util.List;
 import java.util.Optional;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -51,5 +53,19 @@ public interface BlockRepository extends JpaRepository<Block, UUID> {
     List<Block> findActiveByDocumentIdAndParentIdOrderBySortKey(
             @Param("documentId") UUID documentId,
             @Param("parentId") UUID parentId
+    );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Block b
+            set b.deletedAt = :deletedAt,
+                b.updatedBy = :actorId
+            where b.document.id = :documentId
+              and b.deletedAt is null
+            """)
+    void softDeleteActiveByDocumentId(
+            @Param("documentId") UUID documentId,
+            @Param("actorId") String actorId,
+            @Param("deletedAt") LocalDateTime deletedAt
     );
 }

--- a/documents-infrastructure/src/main/java/com/documents/repository/DocumentRepository.java
+++ b/documents-infrastructure/src/main/java/com/documents/repository/DocumentRepository.java
@@ -1,10 +1,12 @@
 package com.documents.repository;
 
 import com.documents.domain.Document;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -38,4 +40,18 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
               d.id asc
             """)
     List<Document> findActiveByWorkspaceIdOrderBySortKey(@Param("workspaceId") UUID workspaceId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Document d
+            set d.deletedAt = :deletedAt,
+                d.updatedBy = :actorId
+            where d.id = :documentId
+              and d.deletedAt is null
+            """)
+    int softDeleteActiveById(
+            @Param("documentId") UUID documentId,
+            @Param("actorId") String actorId,
+            @Param("deletedAt") LocalDateTime deletedAt
+    );
 }

--- a/documents-infrastructure/src/main/java/com/documents/repository/DocumentRepository.java
+++ b/documents-infrastructure/src/main/java/com/documents/repository/DocumentRepository.java
@@ -1,57 +1,71 @@
 package com.documents.repository;
 
-import com.documents.domain.Document;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.documents.domain.Document;
+
 public interface DocumentRepository extends JpaRepository<Document, UUID> {
 
-    Optional<Document> findByIdAndDeletedAtIsNull(UUID id);
+	Optional<Document> findByIdAndDeletedAtIsNull(UUID id);
 
-    @Query("""
-            select max(d.sortKey)
-            from Document d
-            where d.workspace.id = :workspaceId
-              and (
-                (:parentId is null and d.parent is null)
-                or d.parent.id = :parentId
-              )
-              and d.deletedAt is null
-            """)
-    Optional<String> findMaxSortKeyByWorkspaceIdAndParentId(
-            @Param("workspaceId") UUID workspaceId,
-            @Param("parentId") UUID parentId
-    );
+	@Query("""
+		select max(d.sortKey)
+		from Document d
+		where d.workspace.id = :workspaceId
+		  and (
+		    (:parentId is null and d.parent is null)
+		    or d.parent.id = :parentId
+		  )
+		  and d.deletedAt is null
+		""")
+	Optional<String> findMaxSortKeyByWorkspaceIdAndParentId(
+		@Param("workspaceId") UUID workspaceId,
+		@Param("parentId") UUID parentId
+	);
 
-    @Query("""
-            select d
-            from Document d
-            where d.workspace.id = :workspaceId
-              and d.deletedAt is null
-            order by
-              d.sortKey asc,
-              d.createdAt asc,
-              d.id asc
-            """)
-    List<Document> findActiveByWorkspaceIdOrderBySortKey(@Param("workspaceId") UUID workspaceId);
+	@Query("""
+		select d
+		from Document d
+		where d.workspace.id = :workspaceId
+		  and d.deletedAt is null
+		order by
+		  d.sortKey asc,
+		  d.createdAt asc,
+		  d.id asc
+		""")
+	List<Document> findActiveByWorkspaceIdOrderBySortKey(@Param("workspaceId") UUID workspaceId);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("""
-            update Document d
-            set d.deletedAt = :deletedAt,
-                d.updatedBy = :actorId
-            where d.id = :documentId
-              and d.deletedAt is null
-            """)
-    int softDeleteActiveById(
-            @Param("documentId") UUID documentId,
-            @Param("actorId") String actorId,
-            @Param("deletedAt") LocalDateTime deletedAt
-    );
+	@Query("""
+		select d
+		from Document d
+		where d.parent.id = :parentId
+		  and d.deletedAt is null
+		order by
+		  d.sortKey asc,
+		  d.createdAt asc,
+		  d.id asc
+		""")
+	List<Document> findActiveChildrenByParentIdOrderBySortKey(@Param("parentId") UUID parentId);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+		update Document d
+		set d.deletedAt = :deletedAt,
+		    d.updatedBy = :actorId
+		where d.id in :documentIds
+		  and d.deletedAt is null
+		""")
+	int softDeleteActiveByIds(
+		@Param("documentIds") List<UUID> documentIds,
+		@Param("actorId") String actorId,
+		@Param("deletedAt") LocalDateTime deletedAt
+	);
 }

--- a/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
@@ -1,5 +1,6 @@
 package com.documents.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -12,6 +13,7 @@ import com.documents.domain.Document;
 import com.documents.exception.BusinessErrorCode;
 import com.documents.exception.BusinessException;
 import com.documents.repository.BlockRepository;
+import com.documents.repository.DocumentRepository;
 import com.documents.support.OrderedSortKeyGenerator;
 import com.documents.support.OrderedSortKeyGenerator.SortKeyRebalanceRequiredException;
 import com.documents.support.TextNormalizer;
@@ -28,14 +30,14 @@ public class BlockServiceImpl implements BlockService {
     private static final int MAX_BLOCK_DEPTH = 10;
 
     private final BlockRepository blockRepository;
-    private final DocumentService documentService;
+    private final DocumentRepository documentRepository;
     private final TextNormalizer textNormalizer;
     private final OrderedSortKeyGenerator orderedSortKeyGenerator;
 
     @Override
     @Transactional(readOnly = true)
     public List<Block> getAllByDocumentId(UUID documentId) {
-        documentService.getById(documentId);
+        findActiveDocument(documentId);
         return blockRepository.findActiveByDocumentIdOrderBySortKey(documentId);
     }
 
@@ -50,7 +52,7 @@ public class BlockServiceImpl implements BlockService {
             UUID beforeBlockId,
             String actorId
     ) {
-        Document document = documentService.getById(documentId);
+        Document document = findActiveDocument(documentId);
         validateSupportedType(type);
         validateBlockLimit(documentId);
 
@@ -96,6 +98,17 @@ public class BlockServiceImpl implements BlockService {
         block.setText(text);
         block.setUpdatedBy(normalizedActorId);
         return block;
+    }
+
+    @Override
+    @Transactional
+    public void softDeleteAllByDocumentId(UUID documentId, String actorId, LocalDateTime deletedAt) {
+        blockRepository.softDeleteActiveByDocumentId(documentId, actorId, deletedAt);
+    }
+
+    private Document findActiveDocument(UUID documentId) {
+        return documentRepository.findByIdAndDeletedAtIsNull(documentId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
     }
 
     private void validateSupportedType(BlockType type) {

--- a/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
@@ -82,6 +82,13 @@ public class DocumentServiceImpl implements DocumentService {
 		return document;
 	}
 
+	@Override
+	@Transactional
+	public void delete(UUID documentId, String actorId) {
+		findActiveDocument(documentId);
+		textNormalizer.normalizeNullable(actorId);
+	}
+
 	private Document validateParentForWorkspace(UUID workspaceId, UUID parentId) {
 		if (parentId == null) {
 			return null;

--- a/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
@@ -1,6 +1,7 @@
 package com.documents.service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -89,11 +90,11 @@ public class DocumentServiceImpl implements DocumentService {
 	public void delete(UUID documentId, String actorId) {
 		String normalizedActorId = textNormalizer.normalizeNullable(actorId);
 		LocalDateTime deletedAt = LocalDateTime.now();
-		int affectedRowCount = documentRepository.softDeleteActiveById(documentId, normalizedActorId, deletedAt);
-		if (affectedRowCount == 0) {
-			throw new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+		List<UUID> documentIdsToDelete = collectActiveDocumentTreeIds(findActiveDocument(documentId));
+		documentRepository.softDeleteActiveByIds(documentIdsToDelete, normalizedActorId, deletedAt);
+		for (UUID currentDocumentId : documentIdsToDelete) {
+			blockService.softDeleteAllByDocumentId(currentDocumentId, normalizedActorId, deletedAt);
 		}
-		blockService.softDeleteAllByDocumentId(documentId, normalizedActorId, deletedAt);
 	}
 
 	private Document validateParentForWorkspace(UUID workspaceId, UUID parentId) {
@@ -154,6 +155,21 @@ public class DocumentServiceImpl implements DocumentService {
 	private Document findActiveDocument(UUID documentId) {
 		return documentRepository.findByIdAndDeletedAtIsNull(documentId)
 			.orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
+	}
+
+	private List<UUID> collectActiveDocumentTreeIds(Document rootDocument) {
+		List<UUID> documentIds = new ArrayList<>();
+		collectActiveDocumentTreeIds(rootDocument, documentIds);
+		return documentIds;
+	}
+
+	private void collectActiveDocumentTreeIds(Document document, List<UUID> documentIds) {
+		documentIds.add(document.getId());
+
+		List<Document> children = documentRepository.findActiveChildrenByParentIdOrderBySortKey(document.getId());
+		for (Document child : children) {
+			collectActiveDocumentTreeIds(child, documentIds);
+		}
 	}
 
 	private String normalizeNullableMetaJson(String value) {

--- a/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
@@ -1,5 +1,6 @@
 package com.documents.service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -21,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DocumentServiceImpl implements DocumentService {
 
+	private final BlockService blockService;
 	private final DocumentRepository documentRepository;
 	private final WorkspaceService workspaceService;
 	private final TextNormalizer textNormalizer;
@@ -85,8 +87,13 @@ public class DocumentServiceImpl implements DocumentService {
 	@Override
 	@Transactional
 	public void delete(UUID documentId, String actorId) {
-		findActiveDocument(documentId);
-		textNormalizer.normalizeNullable(actorId);
+		String normalizedActorId = textNormalizer.normalizeNullable(actorId);
+		LocalDateTime deletedAt = LocalDateTime.now();
+		int affectedRowCount = documentRepository.softDeleteActiveById(documentId, normalizedActorId, deletedAt);
+		if (affectedRowCount == 0) {
+			throw new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+		}
+		blockService.softDeleteAllByDocumentId(documentId, normalizedActorId, deletedAt);
 	}
 
 	private Document validateParentForWorkspace(UUID workspaceId, UUID parentId) {

--- a/documents-infrastructure/src/test/java/com/documents/service/BlockServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/BlockServiceImplTest.java
@@ -14,6 +14,7 @@ import com.documents.domain.Workspace;
 import com.documents.exception.BusinessErrorCode;
 import com.documents.exception.BusinessException;
 import com.documents.repository.BlockRepository;
+import com.documents.repository.DocumentRepository;
 import com.documents.support.OrderedSortKeyGenerator;
 import com.documents.support.TextNormalizer;
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ class BlockServiceImplTest {
     private BlockRepository blockRepository;
 
     @Mock
-    private DocumentService documentService;
+    private DocumentRepository documentRepository;
 
     @Mock
     private TextNormalizer textNormalizer;
@@ -48,7 +49,7 @@ class BlockServiceImplTest {
     void setUp() {
         blockService = new BlockServiceImpl(
                 blockRepository,
-                documentService,
+                documentRepository,
                 textNormalizer,
                 new OrderedSortKeyGenerator()
         );
@@ -61,7 +62,7 @@ class BlockServiceImplTest {
         Block rootBlock = block(documentId, null, "000000000001000000000000");
         Block childBlock = block(documentId, rootBlock.getId(), "000000000001I00000000000");
 
-        when(documentService.getById(documentId)).thenReturn(document(documentId));
+        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document(documentId)));
         when(blockRepository.findActiveByDocumentIdOrderBySortKey(documentId))
                 .thenReturn(java.util.List.of(rootBlock, childBlock));
 
@@ -73,7 +74,7 @@ class BlockServiceImplTest {
     @DisplayName("성공_루트 텍스트 블록 생성 시 gap 기반 sortKey 전략으로 저장한다")
     void createRootBlockAppendsToDocumentRoot() {
         UUID documentId = UUID.randomUUID();
-        when(documentService.getById(documentId)).thenReturn(document(documentId));
+        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document(documentId)));
         when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(0L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, null))
@@ -104,7 +105,7 @@ class BlockServiceImplTest {
         Block first = block(documentId, parentId, "000000000001000000000000");
         Block second = block(documentId, parentId, "000000000002000000000000");
 
-        when(documentService.getById(documentId)).thenReturn(document(documentId));
+        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document(documentId)));
         when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(2L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.of(
@@ -126,7 +127,7 @@ class BlockServiceImplTest {
         UUID documentId = UUID.randomUUID();
         UUID parentId = UUID.randomUUID();
 
-        when(documentService.getById(documentId)).thenReturn(document(documentId));
+        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document(documentId)));
         when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(0L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findByIdAndDeletedAtIsNull(parentId))
@@ -148,7 +149,7 @@ class BlockServiceImplTest {
     void createBlockThrowsWhenAfterBlockIdIsNotSibling() {
         UUID documentId = UUID.randomUUID();
 
-        when(documentService.getById(documentId)).thenReturn(document(documentId));
+        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document(documentId)));
         when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(0L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, null))
@@ -175,7 +176,7 @@ class BlockServiceImplTest {
         UUID documentId = UUID.randomUUID();
         UUID parentId = UUID.randomUUID();
 
-        when(documentService.getById(documentId)).thenReturn(document(documentId));
+        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document(documentId)));
         when(blockRepository.countActiveByDocumentId(documentId)).thenReturn(0L);
         when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
         when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.empty());

--- a/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
@@ -401,14 +401,16 @@ class DocumentServiceImplTest {
 	@DisplayName("성공_문서 삭제 시 문서와 활성 블록을 같은 시각으로 soft delete 처리한다")
 	void deleteSoftDeletesDocumentAndActiveBlocks() {
 		UUID documentId = UUID.randomUUID();
-		when(documentRepository.softDeleteActiveById(eq(documentId), eq("user-456"), any()))
-			.thenReturn(1);
+		Document targetDocument = document(documentId, UUID.randomUUID(), null, "삭제 대상 문서", "00000000000000000001");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(targetDocument));
+		when(documentRepository.findActiveChildrenByParentIdOrderBySortKey(documentId)).thenReturn(java.util.List.of());
 		when(textNormalizer.normalizeNullable(" user-456 ")).thenReturn("user-456");
 
 		documentService.delete(documentId, " user-456 ");
 
 		ArgumentCaptor<java.time.LocalDateTime> deletedAtCaptor = ArgumentCaptor.forClass(java.time.LocalDateTime.class);
-		verify(documentRepository).softDeleteActiveById(eq(documentId), eq("user-456"), deletedAtCaptor.capture());
+		verify(documentRepository).softDeleteActiveByIds(eq(java.util.List.of(documentId)), eq("user-456"),
+			deletedAtCaptor.capture());
 		verify(blockService).softDeleteAllByDocumentId(eq(documentId), eq("user-456"), eq(deletedAtCaptor.getValue()));
 	}
 
@@ -416,15 +418,44 @@ class DocumentServiceImplTest {
 	@DisplayName("성공_사용자 식별자가 공백이면 block 서비스에도 null 사용자로 위임한다")
 	void deleteDelegatesNullActorToBlockService() {
 		UUID documentId = UUID.randomUUID();
-		when(documentRepository.softDeleteActiveById(eq(documentId), isNull(), any()))
-			.thenReturn(1);
+		Document targetDocument = document(documentId, UUID.randomUUID(), null, "삭제 대상 문서", "00000000000000000001");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(targetDocument));
+		when(documentRepository.findActiveChildrenByParentIdOrderBySortKey(documentId)).thenReturn(java.util.List.of());
 		when(textNormalizer.normalizeNullable(" ")).thenReturn(null);
 
 		documentService.delete(documentId, " ");
 
 		ArgumentCaptor<java.time.LocalDateTime> deletedAtCaptor = ArgumentCaptor.forClass(java.time.LocalDateTime.class);
-		verify(documentRepository).softDeleteActiveById(eq(documentId), isNull(), deletedAtCaptor.capture());
+		verify(documentRepository).softDeleteActiveByIds(eq(java.util.List.of(documentId)), isNull(),
+			deletedAtCaptor.capture());
 		verify(blockService).softDeleteAllByDocumentId(eq(documentId), isNull(), eq(deletedAtCaptor.getValue()));
+	}
+
+	@Test
+	@DisplayName("성공_문서 삭제 시 활성 하위 문서와 각 문서의 블록도 함께 soft delete 처리한다")
+	void deleteSoftDeletesDescendantDocumentsAndBlocks() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID rootId = UUID.randomUUID();
+		UUID childId = UUID.randomUUID();
+		UUID grandChildId = UUID.randomUUID();
+		Document rootDocument = document(rootId, workspaceId, null, "루트 문서", "00000000000000000001");
+		Document childDocument = document(childId, workspaceId, rootId, "하위 문서", "00000000000000000002");
+		Document grandChildDocument = document(grandChildId, workspaceId, childId, "손자 문서", "00000000000000000003");
+		when(documentRepository.findByIdAndDeletedAtIsNull(rootId)).thenReturn(Optional.of(rootDocument));
+		when(documentRepository.findActiveChildrenByParentIdOrderBySortKey(rootId)).thenReturn(java.util.List.of(childDocument));
+		when(documentRepository.findActiveChildrenByParentIdOrderBySortKey(childId))
+			.thenReturn(java.util.List.of(grandChildDocument));
+		when(documentRepository.findActiveChildrenByParentIdOrderBySortKey(grandChildId)).thenReturn(java.util.List.of());
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+
+		documentService.delete(rootId, ACTOR_ID);
+
+		ArgumentCaptor<java.time.LocalDateTime> deletedAtCaptor = ArgumentCaptor.forClass(java.time.LocalDateTime.class);
+		verify(documentRepository, times(1)).softDeleteActiveByIds(eq(java.util.List.of(rootId, childId, grandChildId)),
+			eq(ACTOR_ID), deletedAtCaptor.capture());
+		verify(blockService).softDeleteAllByDocumentId(eq(rootId), eq(ACTOR_ID), eq(deletedAtCaptor.getValue()));
+		verify(blockService).softDeleteAllByDocumentId(eq(childId), eq(ACTOR_ID), eq(deletedAtCaptor.getValue()));
+		verify(blockService).softDeleteAllByDocumentId(eq(grandChildId), eq(ACTOR_ID), eq(deletedAtCaptor.getValue()));
 	}
 
 	@Test
@@ -432,89 +463,12 @@ class DocumentServiceImplTest {
 	void deleteThrowsWhenDocumentMissing() {
 		UUID documentId = UUID.randomUUID();
 		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
-		when(documentRepository.softDeleteActiveById(eq(documentId), eq(ACTOR_ID), any()))
-			.thenReturn(0);
 
 		assertThatThrownBy(() -> documentService.delete(documentId, ACTOR_ID))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("요청한 문서를 찾을 수 없습니다.")
 			.extracting("errorCode")
 			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
-	}
-
-	@Test
-	@DisplayName("성공_활성 문서 삭제 시 문서 벌크 삭제 메서드를 정상 호출한다")
-	void deleteActiveDocumentCallsDocumentSoftDelete() {
-		UUID documentId = UUID.randomUUID();
-		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
-		when(documentRepository.softDeleteActiveById(eq(documentId), eq(ACTOR_ID), any()))
-			.thenReturn(1);
-
-		documentService.delete(documentId, ACTOR_ID);
-
-		verify(documentRepository).softDeleteActiveById(eq(documentId), eq(ACTOR_ID), any());
-	}
-
-	@Test
-	@DisplayName("성공_문서 삭제 시 해당 문서의 활성 블록 soft delete 메서드도 함께 호출한다")
-	void deleteDocumentCallsBlockSoftDelete() {
-		UUID documentId = UUID.randomUUID();
-		when(textNormalizer.normalizeNullable(" user-456 ")).thenReturn("user-456");
-		when(documentRepository.softDeleteActiveById(eq(documentId), eq("user-456"), any()))
-			.thenReturn(1);
-
-		documentService.delete(documentId, " user-456 ");
-
-		verify(blockService).softDeleteAllByDocumentId(eq(documentId), eq("user-456"), any());
-	}
-
-	@Test
-	@DisplayName("성공_문서 삭제와 블록 삭제는 같은 사용자 식별자와 같은 삭제 시각으로 처리한다")
-	void deleteDocumentUsesSameActorAndDeletedAtForDocumentAndBlocks() {
-		UUID documentId = UUID.randomUUID();
-		when(textNormalizer.normalizeNullable(" user-789 ")).thenReturn("user-789");
-		when(documentRepository.softDeleteActiveById(eq(documentId), eq("user-789"), any()))
-			.thenReturn(1);
-
-		documentService.delete(documentId, " user-789 ");
-
-		ArgumentCaptor<java.time.LocalDateTime> deletedAtCaptor = ArgumentCaptor.forClass(java.time.LocalDateTime.class);
-		verify(documentRepository).softDeleteActiveById(eq(documentId), eq("user-789"), deletedAtCaptor.capture());
-		verify(blockService).softDeleteAllByDocumentId(eq(documentId), eq("user-789"), eq(deletedAtCaptor.getValue()));
-	}
-
-	@Test
-	@DisplayName("실패_존재하지 않는 문서 삭제 시 문서 없음 예외를 던진다")
-	void deleteThrowsWhenDocumentDoesNotExist() {
-		UUID documentId = UUID.randomUUID();
-		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
-		when(documentRepository.softDeleteActiveById(eq(documentId), eq(ACTOR_ID), any()))
-			.thenReturn(0);
-
-		assertThatThrownBy(() -> documentService.delete(documentId, ACTOR_ID))
-			.isInstanceOf(BusinessException.class)
-			.hasMessage("요청한 문서를 찾을 수 없습니다.")
-			.extracting("errorCode")
-			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
-
-		verify(blockService, never()).softDeleteAllByDocumentId(any(), any(), any());
-	}
-
-	@Test
-	@DisplayName("실패_이미 삭제된 문서 삭제 시 문서 없음 예외를 던진다")
-	void deleteThrowsWhenDocumentAlreadyDeleted() {
-		UUID documentId = UUID.randomUUID();
-		when(textNormalizer.normalizeNullable(" deleted-user ")).thenReturn("deleted-user");
-		when(documentRepository.softDeleteActiveById(eq(documentId), eq("deleted-user"), any()))
-			.thenReturn(0);
-
-		assertThatThrownBy(() -> documentService.delete(documentId, " deleted-user "))
-			.isInstanceOf(BusinessException.class)
-			.hasMessage("요청한 문서를 찾을 수 없습니다.")
-			.extracting("errorCode")
-			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
-
-		verify(blockService, never()).softDeleteAllByDocumentId(any(), any(), any());
 	}
 
 	private Workspace workspace(UUID workspaceId) {

--- a/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
@@ -442,6 +442,81 @@ class DocumentServiceImplTest {
 			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
 	}
 
+	@Test
+	@DisplayName("성공_활성 문서 삭제 시 문서 벌크 삭제 메서드를 정상 호출한다")
+	void deleteActiveDocumentCallsDocumentSoftDelete() {
+		UUID documentId = UUID.randomUUID();
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+		when(documentRepository.softDeleteActiveById(eq(documentId), eq(ACTOR_ID), any()))
+			.thenReturn(1);
+
+		documentService.delete(documentId, ACTOR_ID);
+
+		verify(documentRepository).softDeleteActiveById(eq(documentId), eq(ACTOR_ID), any());
+	}
+
+	@Test
+	@DisplayName("성공_문서 삭제 시 해당 문서의 활성 블록 soft delete 메서드도 함께 호출한다")
+	void deleteDocumentCallsBlockSoftDelete() {
+		UUID documentId = UUID.randomUUID();
+		when(textNormalizer.normalizeNullable(" user-456 ")).thenReturn("user-456");
+		when(documentRepository.softDeleteActiveById(eq(documentId), eq("user-456"), any()))
+			.thenReturn(1);
+
+		documentService.delete(documentId, " user-456 ");
+
+		verify(blockService).softDeleteAllByDocumentId(eq(documentId), eq("user-456"), any());
+	}
+
+	@Test
+	@DisplayName("성공_문서 삭제와 블록 삭제는 같은 사용자 식별자와 같은 삭제 시각으로 처리한다")
+	void deleteDocumentUsesSameActorAndDeletedAtForDocumentAndBlocks() {
+		UUID documentId = UUID.randomUUID();
+		when(textNormalizer.normalizeNullable(" user-789 ")).thenReturn("user-789");
+		when(documentRepository.softDeleteActiveById(eq(documentId), eq("user-789"), any()))
+			.thenReturn(1);
+
+		documentService.delete(documentId, " user-789 ");
+
+		ArgumentCaptor<java.time.LocalDateTime> deletedAtCaptor = ArgumentCaptor.forClass(java.time.LocalDateTime.class);
+		verify(documentRepository).softDeleteActiveById(eq(documentId), eq("user-789"), deletedAtCaptor.capture());
+		verify(blockService).softDeleteAllByDocumentId(eq(documentId), eq("user-789"), eq(deletedAtCaptor.getValue()));
+	}
+
+	@Test
+	@DisplayName("실패_존재하지 않는 문서 삭제 시 문서 없음 예외를 던진다")
+	void deleteThrowsWhenDocumentDoesNotExist() {
+		UUID documentId = UUID.randomUUID();
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+		when(documentRepository.softDeleteActiveById(eq(documentId), eq(ACTOR_ID), any()))
+			.thenReturn(0);
+
+		assertThatThrownBy(() -> documentService.delete(documentId, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("요청한 문서를 찾을 수 없습니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+
+		verify(blockService, never()).softDeleteAllByDocumentId(any(), any(), any());
+	}
+
+	@Test
+	@DisplayName("실패_이미 삭제된 문서 삭제 시 문서 없음 예외를 던진다")
+	void deleteThrowsWhenDocumentAlreadyDeleted() {
+		UUID documentId = UUID.randomUUID();
+		when(textNormalizer.normalizeNullable(" deleted-user ")).thenReturn("deleted-user");
+		when(documentRepository.softDeleteActiveById(eq(documentId), eq("deleted-user"), any()))
+			.thenReturn(0);
+
+		assertThatThrownBy(() -> documentService.delete(documentId, " deleted-user "))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("요청한 문서를 찾을 수 없습니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+
+		verify(blockService, never()).softDeleteAllByDocumentId(any(), any(), any());
+	}
+
 	private Workspace workspace(UUID workspaceId) {
 		return Workspace.builder()
 			.id(workspaceId)

--- a/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
@@ -1,21 +1,12 @@
 package com.documents.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
-import com.documents.domain.Document;
-import com.documents.domain.Workspace;
-import com.documents.exception.BusinessErrorCode;
-import com.documents.exception.BusinessException;
-import com.documents.repository.DocumentRepository;
-import com.documents.support.DocumentSortKeyGenerator;
-import com.documents.support.TextNormalizer;
 import java.util.Optional;
 import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,398 +15,456 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.documents.domain.Document;
+import com.documents.domain.Workspace;
+import com.documents.exception.BusinessErrorCode;
+import com.documents.exception.BusinessException;
+import com.documents.repository.DocumentRepository;
+import com.documents.support.DocumentSortKeyGenerator;
+import com.documents.support.TextNormalizer;
+
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Document 서비스 구현 검증")
 class DocumentServiceImplTest {
 
-    private static final String ACTOR_ID = "user-123";
-    private static final String ROOT_TITLE = "프로젝트 개요";
+	private static final String ACTOR_ID = "user-123";
+	private static final String ROOT_TITLE = "프로젝트 개요";
 
-    @Mock
-    private DocumentRepository documentRepository;
+	@Mock
+	private BlockService blockService;
 
-    @Mock
-    private WorkspaceService workspaceService;
+	@Mock
+	private DocumentRepository documentRepository;
 
-    @Mock
-    private TextNormalizer textNormalizer;
+	@Mock
+	private WorkspaceService workspaceService;
 
-    @Mock
-    private DocumentSortKeyGenerator documentSortKeyGenerator;
+	@Mock
+	private TextNormalizer textNormalizer;
 
-    @InjectMocks
-    private DocumentServiceImpl documentService;
+	@Mock
+	private DocumentSortKeyGenerator documentSortKeyGenerator;
 
-    @Test
-    @DisplayName("성공_루트 문서 생성 시 워크스페이스와 사용자 식별자를 정규화하여 저장한다")
-    void createRootDocumentNormalizesActorAndStoresDocument() {
-        UUID workspaceId = UUID.randomUUID();
-        when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
-        when(textNormalizer.normalizeNullable(" " + ACTOR_ID + " ")).thenReturn(ACTOR_ID);
-        when(textNormalizer.normalizeRequired("  " + ROOT_TITLE + "  ")).thenReturn(ROOT_TITLE);
-        when(documentSortKeyGenerator.genNextSortKey(workspaceId, null)).thenReturn("00000000000000000001");
-        when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> invocation.getArgument(0));
+	@InjectMocks
+	private DocumentServiceImpl documentService;
 
-        Document result = documentService.create(
-                workspaceId,
-                null,
-                "  " + ROOT_TITLE + "  ",
-                "{\"type\":\"emoji\",\"value\":\"📄\"}",
-                "{\"type\":\"image\",\"value\":\"cover-1\"}",
-                " " + ACTOR_ID + " "
-        );
+	@Test
+	@DisplayName("성공_루트 문서 생성 시 워크스페이스와 사용자 식별자를 정규화하여 저장한다")
+	void createRootDocumentNormalizesActorAndStoresDocument() {
+		UUID workspaceId = UUID.randomUUID();
+		when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
+		when(textNormalizer.normalizeNullable(" " + ACTOR_ID + " ")).thenReturn(ACTOR_ID);
+		when(textNormalizer.normalizeRequired("  " + ROOT_TITLE + "  ")).thenReturn(ROOT_TITLE);
+		when(documentSortKeyGenerator.genNextSortKey(workspaceId, null)).thenReturn("00000000000000000001");
+		when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
-        verify(documentRepository).save(captor.capture());
-        Document request = captor.getValue();
+		Document result = documentService.create(
+			workspaceId,
+			null,
+			"  " + ROOT_TITLE + "  ",
+			"{\"type\":\"emoji\",\"value\":\"📄\"}",
+			"{\"type\":\"image\",\"value\":\"cover-1\"}",
+			" " + ACTOR_ID + " "
+		);
 
-        assertThat(request.getId()).isNotNull();
-        assertThat(request.getWorkspaceId()).isEqualTo(workspaceId);
-        assertThat(request.getParentId()).isNull();
-        assertThat(request.getTitle()).isEqualTo(ROOT_TITLE);
-        assertThat(request.getIconJson()).isEqualTo("{\"type\":\"emoji\",\"value\":\"📄\"}");
-        assertThat(request.getCoverJson()).isEqualTo("{\"type\":\"image\",\"value\":\"cover-1\"}");
-        assertThat(request.getSortKey()).isEqualTo("00000000000000000001");
-        assertThat(request.getCreatedBy()).isEqualTo(ACTOR_ID);
-        assertThat(request.getUpdatedBy()).isEqualTo(ACTOR_ID);
-        assertThat(result).isSameAs(request);
-    }
+		ArgumentCaptor<Document> captor = ArgumentCaptor.forClass(Document.class);
+		verify(documentRepository).save(captor.capture());
+		Document request = captor.getValue();
 
-    @Test
-    @DisplayName("성공_사용자 식별자 헤더가 공백이면 감사 필드를 null로 저장한다")
-    void createDocumentStoresNullActorWhenHeaderIsBlank() {
-        UUID workspaceId = UUID.randomUUID();
-        when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
-        when(textNormalizer.normalizeNullable(" ")).thenReturn(null);
-        when(textNormalizer.normalizeRequired(ROOT_TITLE)).thenReturn(ROOT_TITLE);
-        when(documentSortKeyGenerator.genNextSortKey(workspaceId, null)).thenReturn("00000000000000000001");
-        when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		assertThat(request.getId()).isNotNull();
+		assertThat(request.getWorkspaceId()).isEqualTo(workspaceId);
+		assertThat(request.getParentId()).isNull();
+		assertThat(request.getTitle()).isEqualTo(ROOT_TITLE);
+		assertThat(request.getIconJson()).isEqualTo("{\"type\":\"emoji\",\"value\":\"📄\"}");
+		assertThat(request.getCoverJson()).isEqualTo("{\"type\":\"image\",\"value\":\"cover-1\"}");
+		assertThat(request.getSortKey()).isEqualTo("00000000000000000001");
+		assertThat(request.getCreatedBy()).isEqualTo(ACTOR_ID);
+		assertThat(request.getUpdatedBy()).isEqualTo(ACTOR_ID);
+		assertThat(result).isSameAs(request);
+	}
 
-        Document result = documentService.create(workspaceId, null, ROOT_TITLE, null, null, " ");
+	@Test
+	@DisplayName("성공_사용자 식별자 헤더가 공백이면 감사 필드를 null로 저장한다")
+	void createDocumentStoresNullActorWhenHeaderIsBlank() {
+		UUID workspaceId = UUID.randomUUID();
+		when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
+		when(textNormalizer.normalizeNullable(" ")).thenReturn(null);
+		when(textNormalizer.normalizeRequired(ROOT_TITLE)).thenReturn(ROOT_TITLE);
+		when(documentSortKeyGenerator.genNextSortKey(workspaceId, null)).thenReturn("00000000000000000001");
+		when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        assertThat(result.getCreatedBy()).isNull();
-        assertThat(result.getUpdatedBy()).isNull();
-    }
+		Document result = documentService.create(workspaceId, null, ROOT_TITLE, null, null, " ");
 
-    @Test
-    @DisplayName("성공_부모 문서가 같은 워크스페이스에 있으면 하위 문서를 저장한다")
-    void createChildDocumentWhenParentBelongsToSameWorkspace() {
-        UUID workspaceId = UUID.randomUUID();
-        UUID parentId = UUID.randomUUID();
-        when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
-        when(documentRepository.findByIdAndDeletedAtIsNull(parentId))
-                .thenReturn(Optional.of(parentDocument(parentId, workspaceId)));
-        when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
-        when(textNormalizer.normalizeRequired("하위 문서")).thenReturn("하위 문서");
-        when(documentSortKeyGenerator.genNextSortKey(workspaceId, parentId)).thenReturn("00000000000000000010");
-        when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> invocation.getArgument(0));
+		assertThat(result.getCreatedBy()).isNull();
+		assertThat(result.getUpdatedBy()).isNull();
+	}
 
-        Document result = documentService.create(workspaceId, parentId, "하위 문서", null, null, ACTOR_ID);
+	@Test
+	@DisplayName("성공_부모 문서가 같은 워크스페이스에 있으면 하위 문서를 저장한다")
+	void createChildDocumentWhenParentBelongsToSameWorkspace() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID parentId = UUID.randomUUID();
+		when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
+		when(documentRepository.findByIdAndDeletedAtIsNull(parentId))
+			.thenReturn(Optional.of(parentDocument(parentId, workspaceId)));
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+		when(textNormalizer.normalizeRequired("하위 문서")).thenReturn("하위 문서");
+		when(documentSortKeyGenerator.genNextSortKey(workspaceId, parentId)).thenReturn("00000000000000000010");
+		when(documentRepository.save(any(Document.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        assertThat(result.getParentId()).isEqualTo(parentId);
-        assertThat(result.getSortKey()).isEqualTo("00000000000000000010");
-        verify(documentRepository).findByIdAndDeletedAtIsNull(parentId);
-    }
+		Document result = documentService.create(workspaceId, parentId, "하위 문서", null, null, ACTOR_ID);
 
-    @Test
-    @DisplayName("실패_워크스페이스가 없으면 문서 생성 시 워크스페이스 없음 예외를 던진다")
-    void createDocumentThrowsWhenWorkspaceMissing() {
-        UUID workspaceId = UUID.randomUUID();
-        when(workspaceService.getById(workspaceId))
-                .thenThrow(new BusinessException(BusinessErrorCode.WORKSPACE_NOT_FOUND));
+		assertThat(result.getParentId()).isEqualTo(parentId);
+		assertThat(result.getSortKey()).isEqualTo("00000000000000000010");
+		verify(documentRepository).findByIdAndDeletedAtIsNull(parentId);
+	}
 
-        assertThatThrownBy(() -> documentService.create(workspaceId, null, ROOT_TITLE, null, null, ACTOR_ID))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("요청한 워크스페이스를 찾을 수 없습니다.")
-                .extracting("errorCode")
-                .isEqualTo(BusinessErrorCode.WORKSPACE_NOT_FOUND);
-    }
+	@Test
+	@DisplayName("실패_워크스페이스가 없으면 문서 생성 시 워크스페이스 없음 예외를 던진다")
+	void createDocumentThrowsWhenWorkspaceMissing() {
+		UUID workspaceId = UUID.randomUUID();
+		when(workspaceService.getById(workspaceId))
+			.thenThrow(new BusinessException(BusinessErrorCode.WORKSPACE_NOT_FOUND));
 
-    @Test
-    @DisplayName("실패_부모 문서가 없으면 문서 생성 시 문서 없음 예외를 던진다")
-    void createDocumentThrowsWhenParentMissing() {
-        UUID workspaceId = UUID.randomUUID();
-        UUID parentId = UUID.randomUUID();
-        when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
-        when(documentRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.empty());
+		assertThatThrownBy(() -> documentService.create(workspaceId, null, ROOT_TITLE, null, null, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("요청한 워크스페이스를 찾을 수 없습니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.WORKSPACE_NOT_FOUND);
+	}
 
-        assertThatThrownBy(() -> documentService.create(workspaceId, parentId, ROOT_TITLE, null, null, ACTOR_ID))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("요청한 문서를 찾을 수 없습니다.")
-                .extracting("errorCode")
-                .isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
-    }
+	@Test
+	@DisplayName("실패_부모 문서가 없으면 문서 생성 시 문서 없음 예외를 던진다")
+	void createDocumentThrowsWhenParentMissing() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID parentId = UUID.randomUUID();
+		when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
+		when(documentRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.empty());
 
-    @Test
-    @DisplayName("실패_부모 문서가 다른 워크스페이스에 있으면 잘못된 요청 예외를 던진다")
-    void createDocumentThrowsWhenParentBelongsToOtherWorkspace() {
-        UUID workspaceId = UUID.randomUUID();
-        UUID parentId = UUID.randomUUID();
-        when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
-        when(documentRepository.findByIdAndDeletedAtIsNull(parentId))
-                .thenReturn(Optional.of(parentDocument(parentId, UUID.randomUUID())));
+		assertThatThrownBy(() -> documentService.create(workspaceId, parentId, ROOT_TITLE, null, null, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("요청한 문서를 찾을 수 없습니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+	}
 
-        assertThatThrownBy(() -> documentService.create(workspaceId, parentId, ROOT_TITLE, null, null, ACTOR_ID))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("잘못된 요청입니다.")
-                .extracting("errorCode")
-                .isEqualTo(BusinessErrorCode.INVALID_REQUEST);
-    }
+	@Test
+	@DisplayName("실패_부모 문서가 다른 워크스페이스에 있으면 잘못된 요청 예외를 던진다")
+	void createDocumentThrowsWhenParentBelongsToOtherWorkspace() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID parentId = UUID.randomUUID();
+		when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
+		when(documentRepository.findByIdAndDeletedAtIsNull(parentId))
+			.thenReturn(Optional.of(parentDocument(parentId, UUID.randomUUID())));
 
-    @Test
-    @DisplayName("성공_워크스페이스 문서 목록 조회 시 활성 문서를 반환한다")
-    void getDocumentsByWorkspaceIdReturnsActive() {
-        UUID workspaceId = UUID.randomUUID();
-        Document rootDocument = document(workspaceId, null, "루트 문서", "00000000000000000001");
-        Document childDocument = document(workspaceId, rootDocument.getId(), "하위 문서", "00000000000000000002");
-        when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
-        when(documentRepository.findActiveByWorkspaceIdOrderBySortKey(eq(workspaceId)))
-                .thenReturn(java.util.List.of(rootDocument, childDocument));
+		assertThatThrownBy(() -> documentService.create(workspaceId, parentId, ROOT_TITLE, null, null, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("잘못된 요청입니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+	}
 
-        assertThat(documentService.getAllByWorkspaceId(workspaceId))
-                .containsExactly(rootDocument, childDocument);
-    }
+	@Test
+	@DisplayName("성공_워크스페이스 문서 목록 조회 시 활성 문서를 반환한다")
+	void getDocumentsByWorkspaceIdReturnsActive() {
+		UUID workspaceId = UUID.randomUUID();
+		Document rootDocument = document(workspaceId, null, "루트 문서", "00000000000000000001");
+		Document childDocument = document(workspaceId, rootDocument.getId(), "하위 문서", "00000000000000000002");
+		when(workspaceService.getById(workspaceId)).thenReturn(workspace(workspaceId));
+		when(documentRepository.findActiveByWorkspaceIdOrderBySortKey(eq(workspaceId)))
+			.thenReturn(java.util.List.of(rootDocument, childDocument));
 
-    @Test
-    @DisplayName("실패_존재하지 않는 워크스페이스의 문서 목록 조회는 워크스페이스 없음 예외를 던진다")
-    void getAllByWorkspaceIdThrowsWhenWorkspaceMissing() {
-        UUID workspaceId = UUID.randomUUID();
-        when(workspaceService.getById(workspaceId))
-                .thenThrow(new BusinessException(BusinessErrorCode.WORKSPACE_NOT_FOUND));
+		assertThat(documentService.getAllByWorkspaceId(workspaceId))
+			.containsExactly(rootDocument, childDocument);
+	}
 
-        assertThatThrownBy(() -> documentService.getAllByWorkspaceId(workspaceId))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("요청한 워크스페이스를 찾을 수 없습니다.")
-                .extracting("errorCode")
-                .isEqualTo(BusinessErrorCode.WORKSPACE_NOT_FOUND);
-    }
+	@Test
+	@DisplayName("실패_존재하지 않는 워크스페이스의 문서 목록 조회는 워크스페이스 없음 예외를 던진다")
+	void getAllByWorkspaceIdThrowsWhenWorkspaceMissing() {
+		UUID workspaceId = UUID.randomUUID();
+		when(workspaceService.getById(workspaceId))
+			.thenThrow(new BusinessException(BusinessErrorCode.WORKSPACE_NOT_FOUND));
 
-    @Test
-    @DisplayName("성공_문서 단건 조회 시 활성 문서를 반환한다")
-    void getByIdReturnsActiveDocument() {
-        UUID documentId = UUID.randomUUID();
-        Document document = document(documentId, UUID.randomUUID(), null, "프로젝트 개요", "00000000000000000001");
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
+		assertThatThrownBy(() -> documentService.getAllByWorkspaceId(workspaceId))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("요청한 워크스페이스를 찾을 수 없습니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.WORKSPACE_NOT_FOUND);
+	}
 
-        assertThat(documentService.getById(documentId)).isSameAs(document);
-    }
+	@Test
+	@DisplayName("성공_문서 단건 조회 시 활성 문서를 반환한다")
+	void getByIdReturnsActiveDocument() {
+		UUID documentId = UUID.randomUUID();
+		Document document = document(documentId, UUID.randomUUID(), null, "프로젝트 개요", "00000000000000000001");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
 
-    @Test
-    @DisplayName("실패_soft delete된 문서는 단건 조회에서 제외한다")
-    void getByIdThrowsWhenDocumentMissing() {
-        UUID documentId = UUID.randomUUID();
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.empty());
+		assertThat(documentService.getById(documentId)).isSameAs(document);
+	}
 
-        assertThatThrownBy(() -> documentService.getById(documentId))
-                .isInstanceOf(BusinessException.class)
-                .hasMessage("요청한 문서를 찾을 수 없습니다.")
-                .extracting("errorCode")
-                .isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
-    }
+	@Test
+	@DisplayName("실패_soft delete된 문서는 단건 조회에서 제외한다")
+	void getByIdThrowsWhenDocumentMissing() {
+		UUID documentId = UUID.randomUUID();
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.empty());
 
-    @Test
-    @DisplayName("성공_문서 수정 시 제목은 trim 후 저장하고 updatedBy와 부모를 갱신한다")
-    void updateDocumentTrimsTitleAndUpdatesAuditFields() {
-        UUID workspaceId = UUID.randomUUID();
-        UUID documentId = UUID.randomUUID();
-        UUID parentId = UUID.randomUUID();
-        Document document = document(documentId, workspaceId, null, "기존 제목", "00000000000000000001");
-        document.setIconJson("{\"type\":\"emoji\",\"value\":\"😀\"}");
-        document.setCoverJson("{\"type\":\"image\",\"value\":\"cover-1\"}");
-        document.setUpdatedBy("old-user");
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
-        when(documentRepository.findByIdAndDeletedAtIsNull(parentId))
-                .thenReturn(Optional.of(parentDocument(parentId, workspaceId)));
-        when(textNormalizer.normalizeRequired("  수정된 제목  ")).thenReturn("수정된 제목");
-        when(textNormalizer.normalizeNullable((String) null)).thenReturn(null);
-        when(textNormalizer.normalizeNullable(" user-456 ")).thenReturn("user-456");
+		assertThatThrownBy(() -> documentService.getById(documentId))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("요청한 문서를 찾을 수 없습니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+	}
 
-        Document result = documentService.update(
-                documentId,
-                "  수정된 제목  ",
-                null,
-                null,
-                parentId,
-                " user-456 "
-        );
+	@Test
+	@DisplayName("성공_문서 수정 시 제목은 trim 후 저장하고 updatedBy와 부모를 갱신한다")
+	void updateDocumentTrimsTitleAndUpdatesAuditFields() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID documentId = UUID.randomUUID();
+		UUID parentId = UUID.randomUUID();
+		Document document = document(documentId, workspaceId, null, "기존 제목", "00000000000000000001");
+		document.setIconJson("{\"type\":\"emoji\",\"value\":\"😀\"}");
+		document.setCoverJson("{\"type\":\"image\",\"value\":\"cover-1\"}");
+		document.setUpdatedBy("old-user");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
+		when(documentRepository.findByIdAndDeletedAtIsNull(parentId))
+			.thenReturn(Optional.of(parentDocument(parentId, workspaceId)));
+		when(textNormalizer.normalizeRequired("  수정된 제목  ")).thenReturn("수정된 제목");
+		when(textNormalizer.normalizeNullable((String)null)).thenReturn(null);
+		when(textNormalizer.normalizeNullable(" user-456 ")).thenReturn("user-456");
 
-        assertThat(result).isSameAs(document);
-        assertThat(result.getTitle()).isEqualTo("수정된 제목");
-        assertThat(result.getParentId()).isEqualTo(parentId);
-        assertThat(result.getIconJson()).isNull();
-        assertThat(result.getCoverJson()).isNull();
-        assertThat(result.getUpdatedBy()).isEqualTo("user-456");
-    }
+		Document result = documentService.update(
+			documentId,
+			"  수정된 제목  ",
+			null,
+			null,
+			parentId,
+			" user-456 "
+		);
 
-    @Test
-    @DisplayName("성공_title만 수정하면 다른 필드는 유지한다")
-    void updateDocumentUpdatesOnlyTitle() {
-        UUID workspaceId = UUID.randomUUID();
-        UUID documentId = UUID.randomUUID();
-        Document document = document(documentId, workspaceId, null, "기존 제목", "00000000000000000001");
-        document.setIconJson("{\"type\":\"emoji\",\"value\":\"😀\"}");
-        document.setCoverJson("{\"type\":\"image\",\"value\":\"cover-1\"}");
-        document.setUpdatedBy("old-user");
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
-        when(textNormalizer.normalizeRequired("  새 제목  ")).thenReturn("새 제목");
-        when(textNormalizer.normalizeNullable("{\"type\":\"emoji\",\"value\":\"😀\"}"))
-                .thenReturn("{\"type\":\"emoji\",\"value\":\"😀\"}");
-        when(textNormalizer.normalizeNullable("{\"type\":\"image\",\"value\":\"cover-1\"}"))
-                .thenReturn("{\"type\":\"image\",\"value\":\"cover-1\"}");
-        when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+		assertThat(result).isSameAs(document);
+		assertThat(result.getTitle()).isEqualTo("수정된 제목");
+		assertThat(result.getParentId()).isEqualTo(parentId);
+		assertThat(result.getIconJson()).isNull();
+		assertThat(result.getCoverJson()).isNull();
+		assertThat(result.getUpdatedBy()).isEqualTo("user-456");
+	}
 
-        Document result = documentService.update(
-                documentId,
-                "  새 제목  ",
-                "{\"type\":\"emoji\",\"value\":\"😀\"}",
-                "{\"type\":\"image\",\"value\":\"cover-1\"}",
-                null,
-                ACTOR_ID
-        );
+	@Test
+	@DisplayName("성공_title만 수정하면 다른 필드는 유지한다")
+	void updateDocumentUpdatesOnlyTitle() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID documentId = UUID.randomUUID();
+		Document document = document(documentId, workspaceId, null, "기존 제목", "00000000000000000001");
+		document.setIconJson("{\"type\":\"emoji\",\"value\":\"😀\"}");
+		document.setCoverJson("{\"type\":\"image\",\"value\":\"cover-1\"}");
+		document.setUpdatedBy("old-user");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
+		when(textNormalizer.normalizeRequired("  새 제목  ")).thenReturn("새 제목");
+		when(textNormalizer.normalizeNullable("{\"type\":\"emoji\",\"value\":\"😀\"}"))
+			.thenReturn("{\"type\":\"emoji\",\"value\":\"😀\"}");
+		when(textNormalizer.normalizeNullable("{\"type\":\"image\",\"value\":\"cover-1\"}"))
+			.thenReturn("{\"type\":\"image\",\"value\":\"cover-1\"}");
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
 
-        assertThat(result.getTitle()).isEqualTo("새 제목");
-        assertThat(result.getParentId()).isNull();
-        assertThat(result.getIconJson()).isEqualTo("{\"type\":\"emoji\",\"value\":\"😀\"}");
-        assertThat(result.getCoverJson()).isEqualTo("{\"type\":\"image\",\"value\":\"cover-1\"}");
-        assertThat(result.getUpdatedBy()).isEqualTo(ACTOR_ID);
-    }
+		Document result = documentService.update(
+			documentId,
+			"  새 제목  ",
+			"{\"type\":\"emoji\",\"value\":\"😀\"}",
+			"{\"type\":\"image\",\"value\":\"cover-1\"}",
+			null,
+			ACTOR_ID
+		);
 
-    @Test
-    @DisplayName("성공_title이 null이면 기존 제목을 유지하고 parentId가 null이면 루트로 변경한다")
-    void updateDocumentKeepsTitleWhenNullAndMovesToRoot() {
-        UUID workspaceId = UUID.randomUUID();
-        UUID documentId = UUID.randomUUID();
-        Document document = document(documentId, workspaceId, UUID.randomUUID(), "기존 제목", "00000000000000000001");
-        document.setIconJson("{\"type\":\"emoji\",\"value\":\"😀\"}");
-        document.setCoverJson("{\"type\":\"image\",\"value\":\"cover-1\"}");
-        document.setUpdatedBy("old-user");
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
-        when(textNormalizer.normalizeNullable((String) null)).thenReturn(null);
-        when(textNormalizer.normalizeNullable("{\"type\":\"emoji\",\"value\":\"📄\"}"))
-                .thenReturn("{\"type\":\"emoji\",\"value\":\"📄\"}");
-        when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+		assertThat(result.getTitle()).isEqualTo("새 제목");
+		assertThat(result.getParentId()).isNull();
+		assertThat(result.getIconJson()).isEqualTo("{\"type\":\"emoji\",\"value\":\"😀\"}");
+		assertThat(result.getCoverJson()).isEqualTo("{\"type\":\"image\",\"value\":\"cover-1\"}");
+		assertThat(result.getUpdatedBy()).isEqualTo(ACTOR_ID);
+	}
 
-        Document result = documentService.update(documentId, null, "{\"type\":\"emoji\",\"value\":\"📄\"}", null, null, ACTOR_ID);
+	@Test
+	@DisplayName("성공_title이 null이면 기존 제목을 유지하고 parentId가 null이면 루트로 변경한다")
+	void updateDocumentKeepsTitleWhenNullAndMovesToRoot() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID documentId = UUID.randomUUID();
+		Document document = document(documentId, workspaceId, UUID.randomUUID(), "기존 제목", "00000000000000000001");
+		document.setIconJson("{\"type\":\"emoji\",\"value\":\"😀\"}");
+		document.setCoverJson("{\"type\":\"image\",\"value\":\"cover-1\"}");
+		document.setUpdatedBy("old-user");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
+		when(textNormalizer.normalizeNullable((String)null)).thenReturn(null);
+		when(textNormalizer.normalizeNullable("{\"type\":\"emoji\",\"value\":\"📄\"}"))
+			.thenReturn("{\"type\":\"emoji\",\"value\":\"📄\"}");
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
 
-        assertThat(result.getTitle()).isEqualTo("기존 제목");
-        assertThat(result.getParentId()).isNull();
-        assertThat(result.getIconJson()).isEqualTo("{\"type\":\"emoji\",\"value\":\"📄\"}");
-        assertThat(result.getCoverJson()).isNull();
-        assertThat(result.getUpdatedBy()).isEqualTo(ACTOR_ID);
-    }
+		Document result = documentService.update(documentId, null, "{\"type\":\"emoji\",\"value\":\"📄\"}", null, null,
+			ACTOR_ID);
 
-    @Test
-    @DisplayName("성공_actorId가 공백이면 updatedBy를 null로 저장한다")
-    void updateDocumentStoresNullUpdatedByWhenActorBlank() {
-        UUID documentId = UUID.randomUUID();
-        Document document = document(documentId, UUID.randomUUID(), null, "기존 제목", "00000000000000000001");
-        document.setIconJson("{\"type\":\"emoji\",\"value\":\"😀\"}");
-        document.setCoverJson("{\"type\":\"image\",\"value\":\"cover-1\"}");
-        document.setUpdatedBy("old-user");
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
-        when(textNormalizer.normalizeRequired("수정된 제목")).thenReturn("수정된 제목");
-        when(textNormalizer.normalizeNullable("{\"type\":\"emoji\",\"value\":\"😀\"}"))
-                .thenReturn("{\"type\":\"emoji\",\"value\":\"😀\"}");
-        when(textNormalizer.normalizeNullable("{\"type\":\"image\",\"value\":\"cover-1\"}"))
-                .thenReturn("{\"type\":\"image\",\"value\":\"cover-1\"}");
-        when(textNormalizer.normalizeNullable(" ")).thenReturn(null);
+		assertThat(result.getTitle()).isEqualTo("기존 제목");
+		assertThat(result.getParentId()).isNull();
+		assertThat(result.getIconJson()).isEqualTo("{\"type\":\"emoji\",\"value\":\"📄\"}");
+		assertThat(result.getCoverJson()).isNull();
+		assertThat(result.getUpdatedBy()).isEqualTo(ACTOR_ID);
+	}
 
-        Document result = documentService.update(
-                documentId,
-                "수정된 제목",
-                "{\"type\":\"emoji\",\"value\":\"😀\"}",
-                "{\"type\":\"image\",\"value\":\"cover-1\"}",
-                null,
-                " "
-        );
+	@Test
+	@DisplayName("성공_actorId가 공백이면 updatedBy를 null로 저장한다")
+	void updateDocumentStoresNullUpdatedByWhenActorBlank() {
+		UUID documentId = UUID.randomUUID();
+		Document document = document(documentId, UUID.randomUUID(), null, "기존 제목", "00000000000000000001");
+		document.setIconJson("{\"type\":\"emoji\",\"value\":\"😀\"}");
+		document.setCoverJson("{\"type\":\"image\",\"value\":\"cover-1\"}");
+		document.setUpdatedBy("old-user");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
+		when(textNormalizer.normalizeRequired("수정된 제목")).thenReturn("수정된 제목");
+		when(textNormalizer.normalizeNullable("{\"type\":\"emoji\",\"value\":\"😀\"}"))
+			.thenReturn("{\"type\":\"emoji\",\"value\":\"😀\"}");
+		when(textNormalizer.normalizeNullable("{\"type\":\"image\",\"value\":\"cover-1\"}"))
+			.thenReturn("{\"type\":\"image\",\"value\":\"cover-1\"}");
+		when(textNormalizer.normalizeNullable(" ")).thenReturn(null);
 
-        assertThat(result.getUpdatedBy()).isNull();
-        assertThat(result.getTitle()).isEqualTo("수정된 제목");
-    }
+		Document result = documentService.update(
+			documentId,
+			"수정된 제목",
+			"{\"type\":\"emoji\",\"value\":\"😀\"}",
+			"{\"type\":\"image\",\"value\":\"cover-1\"}",
+			null,
+			" "
+		);
 
-    @Test
-    @DisplayName("실패_자기 자신을 부모로 지정하면 잘못된 요청 예외를 던진다")
-    void updateDocumentThrowsWhenParentIsSelf() {
-        UUID documentId = UUID.randomUUID();
-        Document document = document(documentId, UUID.randomUUID(), null, "기존 제목", "00000000000000000001");
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
+		assertThat(result.getUpdatedBy()).isNull();
+		assertThat(result.getTitle()).isEqualTo("수정된 제목");
+	}
 
-        assertThatThrownBy(() -> documentService.update(documentId, null, null, null, documentId, ACTOR_ID))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(BusinessErrorCode.INVALID_REQUEST);
-    }
+	@Test
+	@DisplayName("실패_자기 자신을 부모로 지정하면 잘못된 요청 예외를 던진다")
+	void updateDocumentThrowsWhenParentIsSelf() {
+		UUID documentId = UUID.randomUUID();
+		Document document = document(documentId, UUID.randomUUID(), null, "기존 제목", "00000000000000000001");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
 
-    @Test
-    @DisplayName("실패_부모 문서가 다른 워크스페이스에 있으면 잘못된 요청 예외를 던진다")
-    void updateDocumentThrowsWhenParentBelongsToOtherWorkspace() {
-        UUID documentId = UUID.randomUUID();
-        UUID parentId = UUID.randomUUID();
-        Document document = document(documentId, UUID.randomUUID(), null, "기존 제목", "00000000000000000001");
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
-        when(documentRepository.findByIdAndDeletedAtIsNull(parentId))
-                .thenReturn(Optional.of(parentDocument(parentId, UUID.randomUUID())));
+		assertThatThrownBy(() -> documentService.update(documentId, null, null, null, documentId, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+	}
 
-        assertThatThrownBy(() -> documentService.update(documentId, null, null, null, parentId, ACTOR_ID))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(BusinessErrorCode.INVALID_REQUEST);
-    }
+	@Test
+	@DisplayName("실패_부모 문서가 다른 워크스페이스에 있으면 잘못된 요청 예외를 던진다")
+	void updateDocumentThrowsWhenParentBelongsToOtherWorkspace() {
+		UUID documentId = UUID.randomUUID();
+		UUID parentId = UUID.randomUUID();
+		Document document = document(documentId, UUID.randomUUID(), null, "기존 제목", "00000000000000000001");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
+		when(documentRepository.findByIdAndDeletedAtIsNull(parentId))
+			.thenReturn(Optional.of(parentDocument(parentId, UUID.randomUUID())));
 
-    @Test
-    @DisplayName("실패_존재하지 않는 부모 문서를 지정하면 문서 없음 예외를 던진다")
-    void updateDocumentThrowsWhenParentMissing() {
-        UUID documentId = UUID.randomUUID();
-        UUID parentId = UUID.randomUUID();
-        Document document = document(documentId, UUID.randomUUID(), null, "기존 제목", "00000000000000000001");
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
-        when(documentRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.empty());
+		assertThatThrownBy(() -> documentService.update(documentId, null, null, null, parentId, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+	}
 
-        assertThatThrownBy(() -> documentService.update(documentId, null, null, null, parentId, ACTOR_ID))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
-    }
+	@Test
+	@DisplayName("실패_존재하지 않는 부모 문서를 지정하면 문서 없음 예외를 던진다")
+	void updateDocumentThrowsWhenParentMissing() {
+		UUID documentId = UUID.randomUUID();
+		UUID parentId = UUID.randomUUID();
+		Document document = document(documentId, UUID.randomUUID(), null, "기존 제목", "00000000000000000001");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
+		when(documentRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.empty());
 
-    @Test
-    @DisplayName("실패_순환 참조가 생기면 잘못된 요청 예외를 던진다")
-    void updateDocumentThrowsWhenCycleDetected() {
-        UUID workspaceId = UUID.randomUUID();
-        UUID documentId = UUID.randomUUID();
-        UUID childId = UUID.randomUUID();
-        Document document = document(documentId, workspaceId, null, "루트 문서", "00000000000000000001");
-        Document childDocument = document(childId, workspaceId, documentId, "하위 문서", "00000000000000000002");
-        when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
-        when(documentRepository.findByIdAndDeletedAtIsNull(childId)).thenReturn(Optional.of(childDocument));
+		assertThatThrownBy(() -> documentService.update(documentId, null, null, null, parentId, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+	}
 
-        assertThatThrownBy(() -> documentService.update(documentId, null, null, null, childId, ACTOR_ID))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(BusinessErrorCode.INVALID_REQUEST);
-    }
+	@Test
+	@DisplayName("실패_순환 참조가 생기면 잘못된 요청 예외를 던진다")
+	void updateDocumentThrowsWhenCycleDetected() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID documentId = UUID.randomUUID();
+		UUID childId = UUID.randomUUID();
+		Document document = document(documentId, workspaceId, null, "루트 문서", "00000000000000000001");
+		Document childDocument = document(childId, workspaceId, documentId, "하위 문서", "00000000000000000002");
+		when(documentRepository.findByIdAndDeletedAtIsNull(documentId)).thenReturn(Optional.of(document));
+		when(documentRepository.findByIdAndDeletedAtIsNull(childId)).thenReturn(Optional.of(childDocument));
 
-    private Workspace workspace(UUID workspaceId) {
-        return Workspace.builder()
-                .id(workspaceId)
-                .name("Docs Root")
-                .build();
-    }
+		assertThatThrownBy(() -> documentService.update(documentId, null, null, null, childId, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+	}
 
-    private Document document(UUID workspaceId, UUID parentId, String title, String sortKey) {
-        return document(UUID.randomUUID(), workspaceId, parentId, title, sortKey);
-    }
+	@Test
+	@DisplayName("성공_문서 삭제 시 문서와 활성 블록을 같은 시각으로 soft delete 처리한다")
+	void deleteSoftDeletesDocumentAndActiveBlocks() {
+		UUID documentId = UUID.randomUUID();
+		when(documentRepository.softDeleteActiveById(eq(documentId), eq("user-456"), any()))
+			.thenReturn(1);
+		when(textNormalizer.normalizeNullable(" user-456 ")).thenReturn("user-456");
 
-    private Document document(UUID documentId, UUID workspaceId, UUID parentId, String title, String sortKey) {
-        return Document.builder()
-                .id(documentId)
-                .workspace(workspace(workspaceId))
-                .parent(parentId == null ? null : parentDocument(parentId, workspaceId))
-                .title(title)
-                .sortKey(sortKey)
-                .build();
-    }
+		documentService.delete(documentId, " user-456 ");
 
-    private Document parentDocument(UUID documentId, UUID workspaceId) {
-        return document(documentId, workspaceId, null, "부모 문서", "00000000000000000001");
-    }
+		ArgumentCaptor<java.time.LocalDateTime> deletedAtCaptor = ArgumentCaptor.forClass(java.time.LocalDateTime.class);
+		verify(documentRepository).softDeleteActiveById(eq(documentId), eq("user-456"), deletedAtCaptor.capture());
+		verify(blockService).softDeleteAllByDocumentId(eq(documentId), eq("user-456"), eq(deletedAtCaptor.getValue()));
+	}
+
+	@Test
+	@DisplayName("성공_사용자 식별자가 공백이면 block 서비스에도 null 사용자로 위임한다")
+	void deleteDelegatesNullActorToBlockService() {
+		UUID documentId = UUID.randomUUID();
+		when(documentRepository.softDeleteActiveById(eq(documentId), isNull(), any()))
+			.thenReturn(1);
+		when(textNormalizer.normalizeNullable(" ")).thenReturn(null);
+
+		documentService.delete(documentId, " ");
+
+		ArgumentCaptor<java.time.LocalDateTime> deletedAtCaptor = ArgumentCaptor.forClass(java.time.LocalDateTime.class);
+		verify(documentRepository).softDeleteActiveById(eq(documentId), isNull(), deletedAtCaptor.capture());
+		verify(blockService).softDeleteAllByDocumentId(eq(documentId), isNull(), eq(deletedAtCaptor.getValue()));
+	}
+
+	@Test
+	@DisplayName("실패_이미 삭제되었거나 없는 문서는 문서 없음 예외를 던진다")
+	void deleteThrowsWhenDocumentMissing() {
+		UUID documentId = UUID.randomUUID();
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+		when(documentRepository.softDeleteActiveById(eq(documentId), eq(ACTOR_ID), any()))
+			.thenReturn(0);
+
+		assertThatThrownBy(() -> documentService.delete(documentId, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("요청한 문서를 찾을 수 없습니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+	}
+
+	private Workspace workspace(UUID workspaceId) {
+		return Workspace.builder()
+			.id(workspaceId)
+			.name("Docs Root")
+			.build();
+	}
+
+	private Document document(UUID workspaceId, UUID parentId, String title, String sortKey) {
+		return document(UUID.randomUUID(), workspaceId, parentId, title, sortKey);
+	}
+
+	private Document document(UUID documentId, UUID workspaceId, UUID parentId, String title, String sortKey) {
+		return Document.builder()
+			.id(documentId)
+			.workspace(workspace(workspaceId))
+			.parent(parentId == null ? null : parentDocument(parentId, workspaceId))
+			.title(title)
+			.sortKey(sortKey)
+			.build();
+	}
+
+	private Document parentDocument(UUID documentId, UUID workspaceId) {
+		return document(documentId, workspaceId, null, "부모 문서", "00000000000000000001");
+	}
+
 }

--- a/prompts/2026-03-18-document-delete-api-skeleton.md
+++ b/prompts/2026-03-18-document-delete-api-skeleton.md
@@ -1,0 +1,6 @@
+# 2026-03-18 문서 삭제 API 스켈레톤
+
+- 작업 목적: 문서 삭제 API 엔드포인트와 서비스 시그니처 추가
+- 변경 범위: `documents-api` 컨트롤러, `documents-core` 서비스 인터페이스, `documents-infrastructure` 최소 구현
+- 제외 범위: soft delete 비즈니스 로직, block 연계 삭제
+- 검증 방식: Gradle `compileJava`로 모듈 컴파일 확인

--- a/prompts/2026-03-18-document-delete-bulk-update.md
+++ b/prompts/2026-03-18-document-delete-bulk-update.md
@@ -1,0 +1,6 @@
+# 2026-03-18 문서 삭제 벌크 연산 정리
+
+- 작업 목적: 문서 삭제와 문서 소속 블록 삭제를 repository 벌크 update 기반으로 정리
+- 변경 범위: `DocumentRepository`, `BlockRepository`, `DocumentServiceImpl`, 관련 서비스 테스트
+- 적용 정책: 문서 벌크 update 결과가 0건이면 `DOCUMENT_NOT_FOUND`
+- 검증 방식: 관련 서비스 테스트와 compile 검증

--- a/prompts/2026-03-18-document-delete-service-tests.md
+++ b/prompts/2026-03-18-document-delete-service-tests.md
@@ -1,0 +1,6 @@
+# 2026-03-18 문서 삭제 서비스 단위 테스트
+
+- 작업 목적: `DocumentServiceImplTest`에 문서 삭제 단위 테스트 보강
+- 변경 범위: `documents-infrastructure` 서비스 테스트 코드만 추가
+- 포함 케이스: 활성 문서 삭제 호출, block soft delete 위임, 동일 actor/deletedAt 전달, 문서 없음, 이미 삭제됨
+- 검증 방식: `DocumentServiceImplTest` 단독 실행

--- a/prompts/2026-03-18-document-delete-service.md
+++ b/prompts/2026-03-18-document-delete-service.md
@@ -1,0 +1,6 @@
+# 2026-03-18 문서 삭제 서비스 로직
+
+- 작업 목적: 문서 1건 soft delete와 소속 활성 블록 soft delete 구현
+- 변경 범위: `documents-infrastructure` 서비스 로직, 서비스 단위 테스트 보강
+- 적용 정책: 활성 문서만 삭제 가능, soft delete 문서는 `DOCUMENT_NOT_FOUND`, block soft delete 동시 처리
+- 검증 방식: 관련 모듈 `test` 및 `compileJava` 실행

--- a/prompts/2026-03-18-document-delete-via-block-service.md
+++ b/prompts/2026-03-18-document-delete-via-block-service.md
@@ -1,0 +1,6 @@
+# 2026-03-18 문서 삭제 블록 위임 정리
+
+- 작업 목적: `DocumentServiceImpl`의 블록 soft delete 직접 접근 제거
+- 변경 범위: `BlockService` 계약 추가, `BlockServiceImpl` bulk update 위임, `DocumentServiceImpl` 의존 방향 정리
+- 구현 포인트: block bulk soft delete는 `BlockRepository` 수정 쿼리로 처리
+- 검증 방식: 관련 서비스 테스트와 compile 검증

--- a/prompts/2026-03-18-document-delete-webmvc-test.md
+++ b/prompts/2026-03-18-document-delete-webmvc-test.md
@@ -1,0 +1,6 @@
+# 2026-03-18 문서 삭제 WebMvc 테스트
+
+- 작업 목적: 문서 삭제 API의 WebMvc 테스트를 기존 `DocumentControllerWebMvcTest`에 추가
+- 변경 범위: `documents-api` 기존 WebMvc 테스트 확장, 잘못 만든 `documents-boot` 테스트 제거
+- 포함 케이스: 정상 삭제, 문서 없음, 이미 삭제됨, 인증 헤더 누락
+- 검증 방식: 대상 WebMvc 테스트 실행

--- a/prompts/2026-03-19-document-delete-api-integration-test.md
+++ b/prompts/2026-03-19-document-delete-api-integration-test.md
@@ -1,0 +1,6 @@
+# 2026-03-19 문서 삭제 API 통합 테스트
+
+- 작업 목적: 문서 삭제 API의 soft delete 통합 검증 추가
+- 변경 범위: `DocumentApiIntegrationTest`에 삭제 성공/조회 실패/문서 없음 케이스 추가
+- 검증 포인트: 문서 deletedAt 저장, 소속 활성 블록 soft delete, 다른 문서 블록 보존
+- 검증 방식: `DocumentApiIntegrationTest` 대상 실행

--- a/prompts/2026-03-19-document-delete-descendant-bulk-fix.md
+++ b/prompts/2026-03-19-document-delete-descendant-bulk-fix.md
@@ -1,0 +1,6 @@
+# 2026-03-19 문서 삭제 하위 문서 bulk soft delete 보완
+
+- 작업 목적: 문서 삭제 시 상위 문서만 soft delete 되던 누락을 수정하고, 활성 하위 문서와 각 문서의 블록까지 함께 삭제되도록 보완
+- 변경 범위: `DocumentRepository`, `DocumentServiceImpl`, 문서 삭제 서비스 테스트, 문서 삭제 API 통합 테스트
+- 구현 요지: 하위 문서를 재귀 수집한 뒤 동일한 `deletedAt`/`actorId`로 문서 bulk update 1회 수행, 이후 각 문서의 블록 soft delete 위임
+- 검증 포인트: 하위 문서 soft delete 전파, 다른 문서 보존, `documents` soft delete update SQL 1회 실행


### PR DESCRIPTION
<!--
제목 작성 요령
[${CONVENTION}] ${구현 내용 요약}

CONVENTION 예시
- [FEAT]  : 새로운 기능 추가
- [FIX]   : 버그 수정
- [REFACTOR] : 코드 리팩터링 (기능 변화 X)
- [CHORE] : 빌드/설정/환경 변경
- [DOCS]  : 문서 수정
-->

## 📝 Part (해당되는 것만 체크)

- [x] BE
- [ ] FE
- [ ] Infra
- [x] Docs
- [x] Test

---

## #️⃣ 연관된 이슈

<!--
이슈와 PR를 자동으로 연결하기 위한 영역입니다.
예시:
- closes #17
- fixes #24
여러 개일 경우 쉼표로 구분해서 적어주세요.
-->

closes #19 

---

## 🔎 작업 내용

<!--
무슨 일을 했는지 "한 눈에" 이해할 수 있게 적어주세요.
가능하면 bullet 형식으로 요약해 주세요.
-->

### 1. 주요 변경 사항 요약

- 문서 삭제 API를 추가했습니다. (`DELETE /v1/documents/{documentId}`)
- 문서 soft delete 시 해당 문서에 속한 활성 블록도 함께 soft delete 되도록 연계 로직을 구현했습니다.
- 문서 삭제 로직을 `bulk update `방식으로 정리하고, 서비스/WebMvc/통합 테스트를 보강했습니다.

### 2. 상세 내용 (선택)

- API 스펙
  - `DELETE /v1/documents/{documentId}`
  - Header: `X-User-Id`
- 삭제 정책
  - 문서는 hard delete가 아닌, soft delete로 처리합니다.
  - 삭제 성공 시 `Document.deletedAt`, `Document.updatedBy`, `updatedAt`이 갱신됩니다.
  - 문서 삭제 시 해당 문서에 속한 활성 Block도 함께 soft delete 됩니다.
  - 다른 문서에 속한 Block은 영향을 받지 않습니다.
- 구현 방식
  - `documents-api`에 문서 삭제 엔드포인트를 추가했습니다.
  - `documents-core`의 `DocumentService` 계약에 삭제 메서드를 추가했습니다.
  - `documents-infrastructure`에서 문서 삭제와 블록 삭제를 하나의 트랜잭션으로 묶었습니다.
  - 문서 삭제와 Block soft delete는 repository의 벌크 update(`@Modifying`) 방식으로 처리했습니다.
- 예외 처리
  - 존재하지 않거나 이미 soft delete된 문서를 삭제하면 `DOCUMENT_NOT_FOUND`를 반환합니다.
  - `X-User-Id` 헤더가 없으면 `UNAUTHORIZED`를 반환합니다.

### 3. 프롬프트 경로

- [/prompts/2026-03-18-document-delete-api-skeleton.md](https://github.com/jho951/Block-server/blob/46e77cd8ab830b84dfebcc0c80944d2dc97fffb4/prompts/2026-03-18-document-delete-api-skeleton.md)
- [/prompts/2026-03-18-document-delete-service.md](https://github.com/jho951/Block-server/blob/46e77cd8ab830b84dfebcc0c80944d2dc97fffb4/prompts/2026-03-18-document-delete-service.md)
- [/prompts/2026-03-18-document-delete-bulk-update.md](https://github.com/jho951/Block-server/blob/46e77cd8ab830b84dfebcc0c80944d2dc97fffb4/prompts/2026-03-18-document-delete-bulk-update.md)
- [/prompts/2026-03-18-document-delete-via-block-service.md](https://github.com/jho951/Block-server/blob/46e77cd8ab830b84dfebcc0c80944d2dc97fffb4/prompts/2026-03-18-document-delete-via-block-service.md)

---

## 💬 집중 리뷰 요청

<!--
리뷰어가 어디를 중점적으로 봐야 하는지 알려주세요.
복잡한 로직, 트레이드오프, 고민했던 포인트를 적어주면 리뷰 품질이 올라갑니다.
-->

- 문서 삭제 시 해당 문서 소속 Block만 함께 soft delete 되도록 잡은 범위가 요구사항에 맞는지 확인 부탁드립니다.
- `DocumentServiceImpl`에서 문서 삭제 후 Block 삭제를 연계하는 책임 분리가 현재 구조에 맞는지 봐주시면 좋겠습니다.
- 문서/블록 soft delete를 `@Modifying` 벌크 update로 처리한 방식이 현재 구조에 맞는지 봐주시면 좋겠습니다.

---

## 🧪 테스트 방법

<!--
리뷰어/테스터가 동일하게 재현할 수 있도록, 테스트 방법을 구체적으로 적어주세요.
로컬/스테이징 환경 기준, 실행 커맨드가 있으면 함께 작성해 주세요.
-->

### 1. 로컬 실행 방법

- `./gradlew :documents-api:test`
- `./gradlew :documents-infrastructure:test`
- `./gradlew :documents-boot:test`

### 2. 테스트 시나리오

- [ ] `DELETE /v1/documents/{documentId}` 호출 시 성공 응답이 반환되는지 확인
- [ ] 존재하지 않는 문서 삭제 시 `DOCUMENT_NOT_FOUND` 응답이 반환되는지 확인
- [ ] 이미 soft delete된 문서 삭제 시 `DOCUMENT_NOT_FOUND` 응답이 반환되는지 확인
- [ ] 문서 삭제 시 해당 문서의 활성 Block도 함께 soft delete 되는지 확인
- [ ] 다른 문서에 속한 Block은 함께 삭제되지 않는지 확인
- [ ] `X-User-Id` 헤더가 없으면 `UNAUTHORIZED` 응답이 반환되는지 확인

---

## ✅ PR 체크리스트

<!--
PR 올리기 전에 스스로 한 번 더 점검하는 용도입니다.
팀 컨벤션에 맞게 자유롭게 수정해서 사용하세요.
-->

- [ ] 불필요한 디버그 로그 / 주석 제거
- [ ] breaking change 여부 확인 및 문서화
- [ ] 신규/변경된 기능에 대한 테스트 코드 추가 또는 기존 테스트 통과
- [ ] 로컬에서 주요 시나리오 수동 테스트 완료
- [ ] 관련 문서(노션, README, API 문서 등) 업데이트