### PR TITLE
feat: 문서 복구 API 구현

### DIFF
--- a/documents-api/src/main/java/com/documents/api/document/DocumentController.java
+++ b/documents-api/src/main/java/com/documents/api/document/DocumentController.java
@@ -33,87 +33,87 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/v1")
 public class DocumentController {
 
-    // TODO: 임시 헤더 값. 인증 서버와 연동 후 수정 필요
-    private static final String USER_ID_HEADER = "X-User-Id";
+	// TODO: 임시 헤더 값. 인증 서버와 연동 후 수정 필요
+	private static final String USER_ID_HEADER = "X-User-Id";
 
-    private final DocumentService documentService;
-    private final DocumentApiMapper documentApiMapper;
+	private final DocumentService documentService;
+	private final DocumentApiMapper documentApiMapper;
 
-    @Operation(summary = "워크스페이스 문서 목록 조회")
-    @GetMapping("/workspaces/{workspaceId}/documents")
-    public ResponseEntity<GlobalResponse<List<DocumentResponse>>> getDocuments(
-            @PathVariable("workspaceId") UUID workspaceId
-    ) {
-        List<DocumentResponse> response = documentService.getAllByWorkspaceId(workspaceId).stream()
-                .map(documentApiMapper::toResponse)
-                .toList();
-        return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, response));
-    }
+	@Operation(summary = "워크스페이스 문서 목록 조회")
+	@GetMapping("/workspaces/{workspaceId}/documents")
+	public ResponseEntity<GlobalResponse<List<DocumentResponse>>> getDocuments(
+		@PathVariable("workspaceId") UUID workspaceId
+	) {
+		List<DocumentResponse> response = documentService.getAllByWorkspaceId(workspaceId).stream()
+			.map(documentApiMapper::toResponse)
+			.toList();
+		return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, response));
+	}
 
-    @Operation(summary = "문서 생성")
-    @PostMapping("/workspaces/{workspaceId}/documents")
-    public ResponseEntity<GlobalResponse<DocumentResponse>> createDocument(
-            @PathVariable("workspaceId") UUID workspaceId,
-            @Valid @RequestBody CreateDocumentRequest request,
-            @RequestHeader(USER_ID_HEADER) String userId
-    ) {
-        Document createdDocument = documentService.create(
-                workspaceId,
-                request.getParentId(),
-                request.getTitle(),
-                documentApiMapper.serializeIcon(request),
-                documentApiMapper.serializeCover(request),
-                userId
-        );
+	@Operation(summary = "문서 생성")
+	@PostMapping("/workspaces/{workspaceId}/documents")
+	public ResponseEntity<GlobalResponse<DocumentResponse>> createDocument(
+		@PathVariable("workspaceId") UUID workspaceId,
+		@Valid @RequestBody CreateDocumentRequest request,
+		@RequestHeader(USER_ID_HEADER) String userId
+	) {
+		Document createdDocument = documentService.create(
+			workspaceId,
+			request.getParentId(),
+			request.getTitle(),
+			documentApiMapper.serializeIcon(request),
+			documentApiMapper.serializeCover(request),
+			userId
+		);
 
-        return ResponseEntity.status(SuccessCode.CREATED.getHttpStatus())
-                .body(GlobalResponse.ok(SuccessCode.CREATED, documentApiMapper.toResponse(createdDocument)));
-    }
+		return ResponseEntity.status(SuccessCode.CREATED.getHttpStatus())
+			.body(GlobalResponse.ok(SuccessCode.CREATED, documentApiMapper.toResponse(createdDocument)));
+	}
 
-    @Operation(summary = "문서 단건 조회")
-    @GetMapping("/documents/{documentId}")
-    public ResponseEntity<GlobalResponse<DocumentResponse>> getDocument(
-            @PathVariable("documentId") UUID documentId
-    ) {
-        Document document = documentService.getById(documentId);
-        return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, documentApiMapper.toResponse(document)));
-    }
+	@Operation(summary = "문서 단건 조회")
+	@GetMapping("/documents/{documentId}")
+	public ResponseEntity<GlobalResponse<DocumentResponse>> getDocument(
+		@PathVariable("documentId") UUID documentId
+	) {
+		Document document = documentService.getById(documentId);
+		return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, documentApiMapper.toResponse(document)));
+	}
 
-    @Operation(summary = "문서 수정")
-    @PatchMapping("/documents/{documentId}")
-    public ResponseEntity<GlobalResponse<DocumentResponse>> updateDocument(
-            @PathVariable("documentId") UUID documentId,
-            @Valid @RequestBody UpdateDocumentRequest request,
-            @RequestHeader(USER_ID_HEADER) String userId
-    ) {
-        Document updatedDocument = documentService.update(
-                documentId,
-                request.getTitle(),
-                documentApiMapper.serializeIcon(request),
-                documentApiMapper.serializeCover(request),
-                request.getParentId(),
-                userId
-        );
-        return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, documentApiMapper.toResponse(updatedDocument)));
-    }
+	@Operation(summary = "문서 수정")
+	@PatchMapping("/documents/{documentId}")
+	public ResponseEntity<GlobalResponse<DocumentResponse>> updateDocument(
+		@PathVariable("documentId") UUID documentId,
+		@Valid @RequestBody UpdateDocumentRequest request,
+		@RequestHeader(USER_ID_HEADER) String userId
+	) {
+		Document updatedDocument = documentService.update(
+			documentId,
+			request.getTitle(),
+			documentApiMapper.serializeIcon(request),
+			documentApiMapper.serializeCover(request),
+			request.getParentId(),
+			userId
+		);
+		return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, documentApiMapper.toResponse(updatedDocument)));
+	}
 
-    @Operation(summary = "문서 삭제")
-    @DeleteMapping("/documents/{documentId}")
-    public ResponseEntity<GlobalResponse<Void>> deleteDocument(
-            @PathVariable("documentId") UUID documentId,
-            @RequestHeader(USER_ID_HEADER) String userId
-    ) {
-        documentService.delete(documentId, userId);
-        return ResponseEntity.ok(GlobalResponse.ok());
-    }
+	@Operation(summary = "문서 삭제")
+	@DeleteMapping("/documents/{documentId}")
+	public ResponseEntity<GlobalResponse<Void>> deleteDocument(
+		@PathVariable("documentId") UUID documentId,
+		@RequestHeader(USER_ID_HEADER) String userId
+	) {
+		documentService.delete(documentId, userId);
+		return ResponseEntity.ok(GlobalResponse.ok());
+	}
 
-    @Operation(summary = "문서 복구")
-    @PatchMapping("/documents/{documentId}/restore")
-    public ResponseEntity<GlobalResponse<Void>> restoreDocument(
-            @PathVariable("documentId") UUID documentId,
-            @RequestHeader(USER_ID_HEADER) String userId
-    ) {
-        documentService.restore(documentId, userId);
-        return ResponseEntity.ok(GlobalResponse.ok());
-    }
+	@Operation(summary = "문서 복구")
+	@PostMapping("/documents/{documentId}/restore")
+	public ResponseEntity<GlobalResponse<Void>> restoreDocument(
+		@PathVariable("documentId") UUID documentId,
+		@RequestHeader(USER_ID_HEADER) String userId
+	) {
+		documentService.restore(documentId, userId);
+		return ResponseEntity.ok(GlobalResponse.ok());
+	}
 }

--- a/documents-api/src/main/java/com/documents/api/document/DocumentController.java
+++ b/documents-api/src/main/java/com/documents/api/document/DocumentController.java
@@ -106,4 +106,14 @@ public class DocumentController {
         documentService.delete(documentId, userId);
         return ResponseEntity.ok(GlobalResponse.ok());
     }
+
+    @Operation(summary = "문서 복구")
+    @PatchMapping("/documents/{documentId}/restore")
+    public ResponseEntity<GlobalResponse<Void>> restoreDocument(
+            @PathVariable("documentId") UUID documentId,
+            @RequestHeader(USER_ID_HEADER) String userId
+    ) {
+        documentService.restore(documentId, userId);
+        return ResponseEntity.ok(GlobalResponse.ok());
+    }
 }

--- a/documents-api/src/test/java/com/documents/api/document/DocumentControllerWebMvcTest.java
+++ b/documents-api/src/test/java/com/documents/api/document/DocumentControllerWebMvcTest.java
@@ -310,6 +310,60 @@ class DocumentControllerWebMvcTest {
 	}
 
 	@Test
+	@DisplayName("성공_soft delete된 문서 복구 요청에 대해 성공 응답을 반환한다")
+	void restoreDocumentReturnsSuccessEnvelope() throws Exception {
+		UUID documentId = UUID.randomUUID();
+
+		mockMvc.perform(patch("/v1/documents/{documentId}/restore", documentId)
+				.header(USER_ID_HEADER, ACTOR_ID))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.httpStatus").value("OK"))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청 응답 성공"))
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.data").doesNotExist());
+
+		verify(documentService).restore(documentId, ACTOR_ID);
+	}
+
+	@Test
+	@DisplayName("실패_존재하지 않는 문서 복구 요청은 문서 없음 응답을 반환한다")
+	void restoreDocumentReturnsNotFoundWhenDocumentMissing() throws Exception {
+		UUID documentId = UUID.randomUUID();
+		doThrow(new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND))
+			.when(documentService).restore(documentId, ACTOR_ID);
+
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}/restore", documentId)
+			.header(USER_ID_HEADER, ACTOR_ID));
+
+		ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_이미 활성 상태인 문서 복구 요청은 문서 없음 응답을 반환한다")
+	void restoreDocumentReturnsNotFoundWhenDocumentAlreadyActive() throws Exception {
+		UUID documentId = UUID.randomUUID();
+		doThrow(new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND))
+			.when(documentService).restore(documentId, ACTOR_ID);
+
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}/restore", documentId)
+			.header(USER_ID_HEADER, ACTOR_ID));
+
+		ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_사용자 식별자 헤더 없이 문서 복구 요청하면 인증 오류 응답을 반환한다")
+	void restoreDocumentReturnsUnauthorizedWhenHeaderMissing() throws Exception {
+		UUID documentId = UUID.randomUUID();
+
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}/restore", documentId));
+
+		ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
+		verify(documentService, never()).restore(any(), any());
+	}
+
+	@Test
 	@DisplayName("실패_icon이 객체 스키마를 따르지 않으면 유효성 검사 오류를 반환한다")
 	void createDocumentRejectsInvalidIconSchema() throws Exception {
 		var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", UUID.randomUUID())

--- a/documents-boot/src/test/java/com/documents/api/document/DocumentApiIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/api/document/DocumentApiIntegrationTest.java
@@ -23,9 +23,9 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
-import com.documents.domain.Document;
 import com.documents.domain.Block;
 import com.documents.domain.BlockType;
+import com.documents.domain.Document;
 import com.documents.domain.Workspace;
 import com.documents.repository.BlockRepository;
 import com.documents.repository.DocumentRepository;
@@ -37,538 +37,608 @@ import com.documents.repository.WorkspaceRepository;
 @DisplayName("Document API 통합 검증")
 class DocumentApiIntegrationTest {
 
-    @Autowired
-    private MockMvc mockMvc;
-
-    @Autowired
-    private WorkspaceRepository workspaceRepository;
-
-    @Autowired
-    private DocumentRepository documentRepository;
-
-    @Autowired
-    private BlockRepository blockRepository;
-
-    @Autowired
-    private DocumentDeleteSqlCounter documentDeleteSqlCounter;
-
-    @BeforeEach
-    void setUp() {
-        blockRepository.deleteAll();
-        documentRepository.deleteAll();
-        workspaceRepository.deleteAll();
-        documentDeleteSqlCounter.reset();
-    }
-
-    @Test
-    @DisplayName("성공_문서 생성 API는 워크스페이스 하위에 루트 문서를 저장하고 응답한다")
-    void createDocumentReturnsCreatedEnvelope() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-
-        mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspace.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "title": "프로젝트 개요",
-                                  "icon": {
-                                    "type": "emoji",
-                                    "value": "📄"
-                                  }
-                                }
-                                """))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.httpStatus").value("CREATED"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("리소스 생성 성공"))
-                .andExpect(jsonPath("$.code").value(201))
-                .andExpect(jsonPath("$.data.workspaceId").value(workspace.getId().toString()))
-                .andExpect(jsonPath("$.data.parentId").doesNotExist())
-                .andExpect(jsonPath("$.data.title").value("프로젝트 개요"))
-                .andExpect(jsonPath("$.data.sortKey").value("00000000000000000001"))
-                .andExpect(jsonPath("$.data.icon.type").value("emoji"))
-                .andExpect(jsonPath("$.data.createdBy").value("user-123"))
-                .andExpect(jsonPath("$.data.version").value(0));
-
-        assertThat(documentRepository.findAll()).hasSize(1);
-        Document savedDocument = documentRepository.findAll().get(0);
-        assertThat(savedDocument.getWorkspaceId()).isEqualTo(workspace.getId());
-        assertThat(savedDocument.getParentId()).isNull();
-        assertThat(savedDocument.getTitle()).isEqualTo("프로젝트 개요");
-        assertThat(savedDocument.getSortKey()).isEqualTo("00000000000000000001");
-        assertThat(savedDocument.getIconJson()).isEqualTo("{\"type\":\"emoji\",\"value\":\"📄\"}");
-        assertThat(savedDocument.getCreatedBy()).isEqualTo("user-123");
-    }
-
-    @Test
-    @DisplayName("성공_워크스페이스 문서 목록 조회 API는 soft delete되지 않은 문서 목록을 반환한다")
-    void getDocumentsReturnsDocumentList() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document rootDocument = saveDocument(workspace.getId(), null, "루트 문서", "00000000000000000001");
-        saveDeletedDocument(workspace.getId(), "삭제된 문서", "00000000000000000099");
-        saveDocument(workspace.getId(), rootDocument.getId(), "하위 문서", "00000000000000000002");
-
-        mockMvc.perform(get("/v1/workspaces/{workspaceId}/documents", workspace.getId()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].title").value("루트 문서"))
-                .andExpect(jsonPath("$.data[1].title").value("하위 문서"));
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 워크스페이스의 문서 목록 조회는 리소스 없음 응답을 반환한다")
-    void getDocumentsReturnsNotFoundWhenWorkspaceMissing() throws Exception {
-        var result = mockMvc.perform(get("/v1/workspaces/{workspaceId}/documents", UUID.randomUUID()));
-
-        assertErrorEnvelope(result, "NOT_FOUND", 9003, "요청한 워크스페이스를 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 워크스페이스로 문서를 생성하면 리소스 없음 응답을 반환한다")
-    void createDocumentReturnsNotFoundWhenWorkspaceMissing() throws Exception {
-        var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "title": "프로젝트 개요"
-                                }
-                                """));
-
-        assertErrorEnvelope(result, "NOT_FOUND", 9003, "요청한 워크스페이스를 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_부모 문서가 다른 워크스페이스에 있으면 잘못된 요청 응답을 반환한다")
-    void createDocumentReturnsBadRequestWhenParentBelongsToOtherWorkspace() throws Exception {
-        Workspace rootWorkspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Root Workspace")
-                .build());
-        Workspace otherWorkspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Other Workspace")
-                .build());
-
-        Document parentDocument = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(otherWorkspace)
-                .title("다른 워크스페이스 문서")
-                .sortKey("00000000000000000001")
-                .build());
-
-        var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", rootWorkspace.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": "%s",
-                                  "title": "프로젝트 개요"
-                                }
-                                """.formatted(parentDocument.getId())));
-
-        assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
-    }
-
-    @Test
-    @DisplayName("실패_icon JSON 스키마가 잘못되면 유효성 검사 오류를 반환한다")
-    void createDocumentReturnsValidationErrorWhenIconSchemaInvalid() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-
-        var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspace.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "title": "프로젝트 개요",
-                                  "icon": "📄"
-                                }
-                                """));
-
-        assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_cover JSON 스키마가 잘못되면 유효성 검사 오류를 반환한다")
-    void createDocumentReturnsValidationErrorWhenCoverSchemaInvalid() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-
-        var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspace.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "title": "프로젝트 개요",
-                                  "cover": {
-                                    "type": "image"
-                                  }
-                                }
-                                """));
-
-        assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_인증 헤더가 없으면 문서 생성 API는 인증 오류를 반환한다")
-    void createDocumentReturnsUnauthorizedWhenHeaderMissing() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-
-        var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspace.getId())
-                        .contentType("application/json")
-                        .content("""
-                                {
-                                  "title": "프로젝트 개요"
-                                }
-                                """));
-
-        assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
-    }
-
-    @Test
-    @DisplayName("성공_문서 단건 조회 API는 저장된 문서 메타데이터를 반환한다")
-    void getDocumentReturnsDocumentEnvelope() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document document = saveDocument(workspace.getId(), null, "프로젝트 개요", "00000000000000000001",
-                "{\"type\":\"emoji\",\"value\":\"📄\"}", null, "user-123", "user-123");
-
-        mockMvc.perform(get("/v1/documents/{documentId}", document.getId()))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value(document.getId().toString()))
-                .andExpect(jsonPath("$.data.workspaceId").value(workspace.getId().toString()))
-                .andExpect(jsonPath("$.data.title").value("프로젝트 개요"))
-                .andExpect(jsonPath("$.data.icon.type").value("emoji"))
-                .andExpect(jsonPath("$.data.createdBy").value("user-123"));
-    }
-
-    @Test
-    @DisplayName("실패_soft delete된 문서 단건 조회는 리소스 없음 응답을 반환한다")
-    void getDocumentReturnsNotFoundWhenDeleted() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document document = saveDeletedDocument(workspace.getId(), "삭제된 문서", "00000000000000000001");
-
-        var result = mockMvc.perform(get("/v1/documents/{documentId}", document.getId()));
-
-        assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("성공_문서 수정 API는 제목 trim, 부모 변경, updatedBy 갱신을 반영한다")
-    void updateDocumentPersistsServiceLogic() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document parentDocument = saveDocument(workspace.getId(), null, "부모 문서", "00000000000000000001");
-        Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000002",
-                "{\"type\":\"emoji\",\"value\":\"😀\"}", "{\"type\":\"image\",\"value\":\"cover-1\"}", null, "user-123");
-
-        mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-456")
-                        .content("""
-                                {
-                                  "title": "  수정된 제목  ",
-                                  "parentId": "%s",
-                                  "icon": null,
-                                  "cover": null
-                                }
-                                """.formatted(parentDocument.getId())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.title").value("수정된 제목"))
-                .andExpect(jsonPath("$.data.parentId").value(parentDocument.getId().toString()))
-                .andExpect(jsonPath("$.data.icon").doesNotExist())
-                .andExpect(jsonPath("$.data.cover").doesNotExist())
-                .andExpect(jsonPath("$.data.updatedBy").value("user-456"))
-                .andExpect(jsonPath("$.data.version").value(1));
-
-        Document updatedDocument = documentRepository.findById(document.getId()).orElseThrow();
-        assertThat(updatedDocument.getTitle()).isEqualTo("수정된 제목");
-        assertThat(updatedDocument.getParentId()).isEqualTo(parentDocument.getId());
-        assertThat(updatedDocument.getIconJson()).isNull();
-        assertThat(updatedDocument.getCoverJson()).isNull();
-        assertThat(updatedDocument.getUpdatedBy()).isEqualTo("user-456");
-    }
-
-    @Test
-    @DisplayName("실패_빈 제목으로 문서를 수정하면 유효성 검사 오류를 반환한다")
-    void updateDocumentReturnsValidationErrorWhenTitleBlank() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000001");
-
-        var result = mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "title": "   "
-                                }
-                                """));
-
-        assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 문서를 수정하면 리소스 없음 응답을 반환한다")
-    void updateDocumentReturnsNotFoundWhenDocumentMissing() throws Exception {
-        var result = mockMvc.perform(patch("/v1/documents/{documentId}", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "title": "수정된 제목"
-                                }
-                                """));
-
-        assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_다른 워크스페이스 부모 문서를 지정하면 잘못된 요청 응답을 반환한다")
-    void updateDocumentReturnsBadRequestWhenParentBelongsToOtherWorkspace() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Workspace otherWorkspace = workspace("Other Workspace");
-        Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000001");
-        Document otherWorkspaceParent = saveDocument(otherWorkspace.getId(), null, "다른 워크스페이스 문서", "00000000000000000001");
-
-        var result = mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "title": "수정된 제목",
-                                  "parentId": "%s"
-                                }
-                                """.formatted(otherWorkspaceParent.getId())));
-
-        assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
-    }
-
-    @Test
-    @DisplayName("실패_자기 자신을 부모로 지정하면 잘못된 요청 응답을 반환한다")
-    void updateDocumentReturnsBadRequestWhenParentIsSelf() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000001");
-
-        var result = mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "title": "수정된 제목",
-                                  "parentId": "%s"
-                                }
-                                """.formatted(document.getId())));
-
-        assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
-    }
-
-    @Test
-    @DisplayName("실패_하위 문서를 부모로 올려 순환 참조가 생기면 잘못된 요청 오류를 반환한다")
-    void updateDocumentReturnsBadRequestWhenCycleDetected() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document rootDocument = saveDocument(workspace.getId(), null, "루트 문서", "00000000000000000001");
-        Document childDocument = saveDocument(workspace.getId(), rootDocument.getId(), "하위 문서", "00000000000000000002");
-
-        var result = mockMvc.perform(patch("/v1/documents/{documentId}", rootDocument.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "title": "수정된 제목",
-                                  "parentId": "%s"
-                                }
-                                """.formatted(childDocument.getId())));
-
-        assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
-    }
-
-    @Test
-    @DisplayName("실패_문서 수정 요청에 제목이 없으면 유효성 검사 오류를 반환한다")
-    void updateDocumentReturnsValidationErrorWhenTitleMissing() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000001");
-
-        var result = mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": null
-                                }
-                                """));
-
-        assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("성공_문서 삭제 API는 하위 문서와 각 문서의 활성 블록까지 soft delete 처리한다")
-    void deleteDocumentSoftDeletesDescendantDocumentsAndBlocks() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document targetDocument = saveDocument(workspace.getId(), null, "삭제 대상 문서", "00000000000000000001");
-        Document childDocument = saveDocument(workspace.getId(), targetDocument.getId(), "하위 문서", "00000000000000000002");
-        Document otherDocument = saveDocument(workspace.getId(), null, "다른 문서", "00000000000000000002");
-
-        Block targetRootBlock = saveBlock(targetDocument.getId(), null, "대상 루트 블록", "000000000001000000000000");
-        Block targetChildBlock = saveBlock(targetDocument.getId(), targetRootBlock.getId(), "대상 자식 블록", "000000000001I00000000000");
-        Block childDocumentBlock = saveBlock(childDocument.getId(), null, "하위 문서 블록", "000000000001000000000000");
-        Block otherDocumentBlock = saveBlock(otherDocument.getId(), null, "다른 문서 블록", "000000000001000000000000");
-        documentDeleteSqlCounter.reset();
-
-        mockMvc.perform(delete("/v1/documents/{documentId}", targetDocument.getId())
-                        .header("X-User-Id", "user-123"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200));
-
-        Document deletedDocument = documentRepository.findById(targetDocument.getId()).orElseThrow();
-        Document deletedChildDocument = documentRepository.findById(childDocument.getId()).orElseThrow();
-        assertThat(deletedDocument.getDeletedAt()).isNotNull();
-        assertThat(deletedChildDocument.getDeletedAt()).isNotNull();
-
-        Block deletedRootBlock = blockRepository.findById(targetRootBlock.getId()).orElseThrow();
-        Block deletedChildBlock = blockRepository.findById(targetChildBlock.getId()).orElseThrow();
-        Block deletedDescendantDocumentBlock = blockRepository.findById(childDocumentBlock.getId()).orElseThrow();
-        Block survivedOtherBlock = blockRepository.findById(otherDocumentBlock.getId()).orElseThrow();
-
-        assertThat(deletedRootBlock.getDeletedAt()).isNotNull();
-        assertThat(deletedChildBlock.getDeletedAt()).isNotNull();
-        assertThat(deletedDescendantDocumentBlock.getDeletedAt()).isNotNull();
-        assertThat(survivedOtherBlock.getDeletedAt()).isNull();
-        assertThat(documentDeleteSqlCounter.documentSoftDeleteUpdateCount()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("성공_문서 삭제 후 같은 문서를 단건 조회하면 문서 없음 응답을 반환한다")
-    void getDocumentReturnsNotFoundAfterDelete() throws Exception {
-        Workspace workspace = workspace("Docs Root");
-        Document document = saveDocument(workspace.getId(), null, "삭제 대상 문서", "00000000000000000001");
-        saveBlock(document.getId(), null, "대상 블록", "000000000001000000000000");
-
-        mockMvc.perform(delete("/v1/documents/{documentId}", document.getId())
-                        .header("X-User-Id", "user-123"))
-                .andExpect(status().isOk());
-
-        var result = mockMvc.perform(get("/v1/documents/{documentId}", document.getId()));
-
-        assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 문서를 삭제하면 문서 없음 응답을 반환한다")
-    void deleteDocumentReturnsNotFoundWhenDocumentMissing() throws Exception {
-        var result = mockMvc.perform(delete("/v1/documents/{documentId}", UUID.randomUUID())
-                        .header("X-User-Id", "user-123"));
-
-        assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
-    }
-
-    private void assertErrorEnvelope(ResultActions result, String httpStatus, int code, String message) throws Exception {
-        result.andExpect(status().is(org.springframework.http.HttpStatus.valueOf(httpStatus).value()))
-                .andExpect(jsonPath("$.httpStatus").value(httpStatus))
-                .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.message").value(message))
-                .andExpect(jsonPath("$.code").value(code))
-                .andExpect(jsonPath("$.data").doesNotExist());
-    }
-
-    private Workspace workspace(String name) {
-        return workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name(name)
-                .build());
-    }
-
-    private Document saveDocument(UUID workspaceId, UUID parentId, String title, String sortKey) {
-        return saveDocument(workspaceId, parentId, title, sortKey, null, null, null, null);
-    }
-
-    private Document saveDocument(
-            UUID workspaceId,
-            UUID parentId,
-            String title,
-            String sortKey,
-            String iconJson,
-            String coverJson,
-            String createdBy,
-            String updatedBy
-    ) {
-        return documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspaceRepository.getReferenceById(workspaceId))
-                .parent(parentId == null ? null : documentRepository.getReferenceById(parentId))
-                .title(title)
-                .sortKey(sortKey)
-                .iconJson(iconJson)
-                .coverJson(coverJson)
-                .createdBy(createdBy)
-                .updatedBy(updatedBy)
-                .build());
-    }
-
-    private Document saveDeletedDocument(UUID workspaceId, String title, String sortKey) {
-        return documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspaceRepository.getReferenceById(workspaceId))
-                .title(title)
-                .sortKey(sortKey)
-                .deletedAt(LocalDateTime.of(2026, 3, 16, 0, 0))
-                .build());
-    }
-
-    private Block saveBlock(UUID documentId, UUID parentId, String content, String sortKey) {
-        return blockRepository.save(Block.builder()
-                .id(UUID.randomUUID())
-                .document(documentRepository.getReferenceById(documentId))
-                .parent(parentId == null ? null : blockRepository.getReferenceById(parentId))
-                .type(BlockType.TEXT)
-                .content(toContent(content))
-                .sortKey(sortKey)
-                .createdBy("user-123")
-                .updatedBy("user-123")
-                .build());
-    }
-
-    private String toContent(String content) {
-        return "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"%s\",\"marks\":[]}]}".formatted(content);
-    }
-
-    @TestConfiguration
-    static class DocumentDeleteSqlCounterTestConfig {
-
-        @Bean
-        DocumentDeleteSqlCounter documentDeleteSqlCounter() {
-            return new DocumentDeleteSqlCounter();
-        }
-
-        @Bean
-        HibernatePropertiesCustomizer documentDeleteSqlCounterCustomizer(DocumentDeleteSqlCounter counter) {
-            return properties -> properties.put("hibernate.session_factory.statement_inspector", counter);
-        }
-    }
-
-    static class DocumentDeleteSqlCounter implements StatementInspector {
-
-        private final AtomicInteger documentSoftDeleteUpdateCount = new AtomicInteger();
-
-        @Override
-        public String inspect(String sql) {
-            String normalizedSql = sql.toLowerCase(Locale.ROOT);
-            if (normalizedSql.contains("update documents") && normalizedSql.contains("deleted_at")) {
-                documentSoftDeleteUpdateCount.incrementAndGet();
-            }
-            return sql;
-        }
-
-        void reset() {
-            documentSoftDeleteUpdateCount.set(0);
-        }
-
-        int documentSoftDeleteUpdateCount() {
-            return documentSoftDeleteUpdateCount.get();
-        }
-    }
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private WorkspaceRepository workspaceRepository;
+
+	@Autowired
+	private DocumentRepository documentRepository;
+
+	@Autowired
+	private BlockRepository blockRepository;
+
+	@Autowired
+	private DocumentDeleteSqlCounter documentDeleteSqlCounter;
+
+	@BeforeEach
+	void setUp() {
+		blockRepository.deleteAll();
+		documentRepository.deleteAll();
+		workspaceRepository.deleteAll();
+		documentDeleteSqlCounter.reset();
+	}
+
+	@Test
+	@DisplayName("성공_문서 생성 API는 워크스페이스 하위에 루트 문서를 저장하고 응답한다")
+	void createDocumentReturnsCreatedEnvelope() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+
+		mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspace.getId())
+				.contentType("application/json")
+				.header("X-User-Id", "user-123")
+				.content("""
+					{
+					  "title": "프로젝트 개요",
+					  "icon": {
+					    "type": "emoji",
+					    "value": "📄"
+					  }
+					}
+					"""))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.httpStatus").value("CREATED"))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("리소스 생성 성공"))
+			.andExpect(jsonPath("$.code").value(201))
+			.andExpect(jsonPath("$.data.workspaceId").value(workspace.getId().toString()))
+			.andExpect(jsonPath("$.data.parentId").doesNotExist())
+			.andExpect(jsonPath("$.data.title").value("프로젝트 개요"))
+			.andExpect(jsonPath("$.data.sortKey").value("00000000000000000001"))
+			.andExpect(jsonPath("$.data.icon.type").value("emoji"))
+			.andExpect(jsonPath("$.data.createdBy").value("user-123"))
+			.andExpect(jsonPath("$.data.version").value(0));
+
+		assertThat(documentRepository.findAll()).hasSize(1);
+		Document savedDocument = documentRepository.findAll().get(0);
+		assertThat(savedDocument.getWorkspaceId()).isEqualTo(workspace.getId());
+		assertThat(savedDocument.getParentId()).isNull();
+		assertThat(savedDocument.getTitle()).isEqualTo("프로젝트 개요");
+		assertThat(savedDocument.getSortKey()).isEqualTo("00000000000000000001");
+		assertThat(savedDocument.getIconJson()).isEqualTo("{\"type\":\"emoji\",\"value\":\"📄\"}");
+		assertThat(savedDocument.getCreatedBy()).isEqualTo("user-123");
+	}
+
+	@Test
+	@DisplayName("성공_워크스페이스 문서 목록 조회 API는 soft delete되지 않은 문서 목록을 반환한다")
+	void getDocumentsReturnsDocumentList() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document rootDocument = saveDocument(workspace.getId(), null, "루트 문서", "00000000000000000001");
+		saveDeletedDocument(workspace.getId(), "삭제된 문서", "00000000000000000099");
+		saveDocument(workspace.getId(), rootDocument.getId(), "하위 문서", "00000000000000000002");
+
+		mockMvc.perform(get("/v1/workspaces/{workspaceId}/documents", workspace.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.httpStatus").value("OK"))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.data.length()").value(2))
+			.andExpect(jsonPath("$.data[0].title").value("루트 문서"))
+			.andExpect(jsonPath("$.data[1].title").value("하위 문서"));
+	}
+
+	@Test
+	@DisplayName("실패_존재하지 않는 워크스페이스의 문서 목록 조회는 리소스 없음 응답을 반환한다")
+	void getDocumentsReturnsNotFoundWhenWorkspaceMissing() throws Exception {
+		var result = mockMvc.perform(get("/v1/workspaces/{workspaceId}/documents", UUID.randomUUID()));
+
+		assertErrorEnvelope(result, "NOT_FOUND", 9003, "요청한 워크스페이스를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_존재하지 않는 워크스페이스로 문서를 생성하면 리소스 없음 응답을 반환한다")
+	void createDocumentReturnsNotFoundWhenWorkspaceMissing() throws Exception {
+		var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", UUID.randomUUID())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "title": "프로젝트 개요"
+				}
+				"""));
+
+		assertErrorEnvelope(result, "NOT_FOUND", 9003, "요청한 워크스페이스를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_부모 문서가 다른 워크스페이스에 있으면 잘못된 요청 응답을 반환한다")
+	void createDocumentReturnsBadRequestWhenParentBelongsToOtherWorkspace() throws Exception {
+		Workspace rootWorkspace = workspaceRepository.save(Workspace.builder()
+			.id(UUID.randomUUID())
+			.name("Root Workspace")
+			.build());
+		Workspace otherWorkspace = workspaceRepository.save(Workspace.builder()
+			.id(UUID.randomUUID())
+			.name("Other Workspace")
+			.build());
+
+		Document parentDocument = documentRepository.save(Document.builder()
+			.id(UUID.randomUUID())
+			.workspace(otherWorkspace)
+			.title("다른 워크스페이스 문서")
+			.sortKey("00000000000000000001")
+			.build());
+
+		var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", rootWorkspace.getId())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "parentId": "%s",
+				  "title": "프로젝트 개요"
+				}
+				""".formatted(parentDocument.getId())));
+
+		assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
+	}
+
+	@Test
+	@DisplayName("실패_icon JSON 스키마가 잘못되면 유효성 검사 오류를 반환한다")
+	void createDocumentReturnsValidationErrorWhenIconSchemaInvalid() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+
+		var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspace.getId())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "title": "프로젝트 개요",
+				  "icon": "📄"
+				}
+				"""));
+
+		assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_cover JSON 스키마가 잘못되면 유효성 검사 오류를 반환한다")
+	void createDocumentReturnsValidationErrorWhenCoverSchemaInvalid() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+
+		var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspace.getId())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "title": "프로젝트 개요",
+				  "cover": {
+				    "type": "image"
+				  }
+				}
+				"""));
+
+		assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_인증 헤더가 없으면 문서 생성 API는 인증 오류를 반환한다")
+	void createDocumentReturnsUnauthorizedWhenHeaderMissing() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+
+		var result = mockMvc.perform(post("/v1/workspaces/{workspaceId}/documents", workspace.getId())
+			.contentType("application/json")
+			.content("""
+				{
+				  "title": "프로젝트 개요"
+				}
+				"""));
+
+		assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
+	}
+
+	@Test
+	@DisplayName("성공_문서 단건 조회 API는 저장된 문서 메타데이터를 반환한다")
+	void getDocumentReturnsDocumentEnvelope() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document document = saveDocument(workspace.getId(), null, "프로젝트 개요", "00000000000000000001",
+			"{\"type\":\"emoji\",\"value\":\"📄\"}", null, "user-123", "user-123");
+
+		mockMvc.perform(get("/v1/documents/{documentId}", document.getId()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.httpStatus").value("OK"))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.data.id").value(document.getId().toString()))
+			.andExpect(jsonPath("$.data.workspaceId").value(workspace.getId().toString()))
+			.andExpect(jsonPath("$.data.title").value("프로젝트 개요"))
+			.andExpect(jsonPath("$.data.icon.type").value("emoji"))
+			.andExpect(jsonPath("$.data.createdBy").value("user-123"));
+	}
+
+	@Test
+	@DisplayName("실패_soft delete된 문서 단건 조회는 리소스 없음 응답을 반환한다")
+	void getDocumentReturnsNotFoundWhenDeleted() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document document = saveDeletedDocument(workspace.getId(), "삭제된 문서", "00000000000000000001");
+
+		var result = mockMvc.perform(get("/v1/documents/{documentId}", document.getId()));
+
+		assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("성공_문서 수정 API는 제목 trim, 부모 변경, updatedBy 갱신을 반영한다")
+	void updateDocumentPersistsServiceLogic() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document parentDocument = saveDocument(workspace.getId(), null, "부모 문서", "00000000000000000001");
+		Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000002",
+			"{\"type\":\"emoji\",\"value\":\"😀\"}", "{\"type\":\"image\",\"value\":\"cover-1\"}", null, "user-123");
+
+		mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
+				.contentType("application/json")
+				.header("X-User-Id", "user-456")
+				.content("""
+					{
+					  "title": "  수정된 제목  ",
+					  "parentId": "%s",
+					  "icon": null,
+					  "cover": null
+					}
+					""".formatted(parentDocument.getId())))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.title").value("수정된 제목"))
+			.andExpect(jsonPath("$.data.parentId").value(parentDocument.getId().toString()))
+			.andExpect(jsonPath("$.data.icon").doesNotExist())
+			.andExpect(jsonPath("$.data.cover").doesNotExist())
+			.andExpect(jsonPath("$.data.updatedBy").value("user-456"))
+			.andExpect(jsonPath("$.data.version").value(1));
+
+		Document updatedDocument = documentRepository.findById(document.getId()).orElseThrow();
+		assertThat(updatedDocument.getTitle()).isEqualTo("수정된 제목");
+		assertThat(updatedDocument.getParentId()).isEqualTo(parentDocument.getId());
+		assertThat(updatedDocument.getIconJson()).isNull();
+		assertThat(updatedDocument.getCoverJson()).isNull();
+		assertThat(updatedDocument.getUpdatedBy()).isEqualTo("user-456");
+	}
+
+	@Test
+	@DisplayName("실패_빈 제목으로 문서를 수정하면 유효성 검사 오류를 반환한다")
+	void updateDocumentReturnsValidationErrorWhenTitleBlank() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000001");
+
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "title": "   "
+				}
+				"""));
+
+		assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_존재하지 않는 문서를 수정하면 리소스 없음 응답을 반환한다")
+	void updateDocumentReturnsNotFoundWhenDocumentMissing() throws Exception {
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}", UUID.randomUUID())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "title": "수정된 제목"
+				}
+				"""));
+
+		assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_다른 워크스페이스 부모 문서를 지정하면 잘못된 요청 응답을 반환한다")
+	void updateDocumentReturnsBadRequestWhenParentBelongsToOtherWorkspace() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Workspace otherWorkspace = workspace("Other Workspace");
+		Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000001");
+		Document otherWorkspaceParent = saveDocument(otherWorkspace.getId(), null, "다른 워크스페이스 문서",
+			"00000000000000000001");
+
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "title": "수정된 제목",
+				  "parentId": "%s"
+				}
+				""".formatted(otherWorkspaceParent.getId())));
+
+		assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
+	}
+
+	@Test
+	@DisplayName("실패_자기 자신을 부모로 지정하면 잘못된 요청 응답을 반환한다")
+	void updateDocumentReturnsBadRequestWhenParentIsSelf() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000001");
+
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "title": "수정된 제목",
+				  "parentId": "%s"
+				}
+				""".formatted(document.getId())));
+
+		assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
+	}
+
+	@Test
+	@DisplayName("실패_하위 문서를 부모로 올려 순환 참조가 생기면 잘못된 요청 오류를 반환한다")
+	void updateDocumentReturnsBadRequestWhenCycleDetected() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document rootDocument = saveDocument(workspace.getId(), null, "루트 문서", "00000000000000000001");
+		Document childDocument = saveDocument(workspace.getId(), rootDocument.getId(), "하위 문서", "00000000000000000002");
+
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}", rootDocument.getId())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "title": "수정된 제목",
+				  "parentId": "%s"
+				}
+				""".formatted(childDocument.getId())));
+
+		assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
+	}
+
+	@Test
+	@DisplayName("실패_문서 수정 요청에 제목이 없으면 유효성 검사 오류를 반환한다")
+	void updateDocumentReturnsValidationErrorWhenTitleMissing() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document document = saveDocument(workspace.getId(), null, "기존 제목", "00000000000000000001");
+
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}", document.getId())
+			.contentType("application/json")
+			.header("X-User-Id", "user-123")
+			.content("""
+				{
+				  "parentId": null
+				}
+				"""));
+
+		assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
+	}
+
+	@Test
+	@DisplayName("성공_문서 삭제 API는 하위 문서와 각 문서의 활성 블록까지 soft delete 처리한다")
+	void deleteDocumentSoftDeletesDescendantDocumentsAndBlocks() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document targetDocument = saveDocument(workspace.getId(), null, "삭제 대상 문서", "00000000000000000001");
+		Document childDocument = saveDocument(workspace.getId(), targetDocument.getId(), "하위 문서",
+			"00000000000000000002");
+		Document otherDocument = saveDocument(workspace.getId(), null, "다른 문서", "00000000000000000002");
+
+		Block targetRootBlock = saveBlock(targetDocument.getId(), null, "대상 루트 블록", "000000000001000000000000");
+		Block targetChildBlock = saveBlock(targetDocument.getId(), targetRootBlock.getId(), "대상 자식 블록",
+			"000000000001I00000000000");
+		Block childDocumentBlock = saveBlock(childDocument.getId(), null, "하위 문서 블록", "000000000001000000000000");
+		Block otherDocumentBlock = saveBlock(otherDocument.getId(), null, "다른 문서 블록", "000000000001000000000000");
+		documentDeleteSqlCounter.reset();
+
+		mockMvc.perform(delete("/v1/documents/{documentId}", targetDocument.getId())
+				.header("X-User-Id", "user-123"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.httpStatus").value("OK"))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.code").value(200));
+
+		Document deletedDocument = documentRepository.findById(targetDocument.getId()).orElseThrow();
+		Document deletedChildDocument = documentRepository.findById(childDocument.getId()).orElseThrow();
+		assertThat(deletedDocument.getDeletedAt()).isNotNull();
+		assertThat(deletedChildDocument.getDeletedAt()).isNotNull();
+
+		Block deletedRootBlock = blockRepository.findById(targetRootBlock.getId()).orElseThrow();
+		Block deletedChildBlock = blockRepository.findById(targetChildBlock.getId()).orElseThrow();
+		Block deletedDescendantDocumentBlock = blockRepository.findById(childDocumentBlock.getId()).orElseThrow();
+		Block survivedOtherBlock = blockRepository.findById(otherDocumentBlock.getId()).orElseThrow();
+
+		assertThat(deletedRootBlock.getDeletedAt()).isNotNull();
+		assertThat(deletedChildBlock.getDeletedAt()).isNotNull();
+		assertThat(deletedDescendantDocumentBlock.getDeletedAt()).isNotNull();
+		assertThat(survivedOtherBlock.getDeletedAt()).isNull();
+		assertThat(documentDeleteSqlCounter.documentSoftDeleteUpdateCount()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("성공_문서 삭제 후 같은 문서를 단건 조회하면 문서 없음 응답을 반환한다")
+	void getDocumentReturnsNotFoundAfterDelete() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document document = saveDocument(workspace.getId(), null, "삭제 대상 문서", "00000000000000000001");
+		saveBlock(document.getId(), null, "대상 블록", "000000000001000000000000");
+
+		mockMvc.perform(delete("/v1/documents/{documentId}", document.getId())
+				.header("X-User-Id", "user-123"))
+			.andExpect(status().isOk());
+
+		var result = mockMvc.perform(get("/v1/documents/{documentId}", document.getId()));
+
+		assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_존재하지 않는 문서를 삭제하면 문서 없음 응답을 반환한다")
+	void deleteDocumentReturnsNotFoundWhenDocumentMissing() throws Exception {
+		var result = mockMvc.perform(delete("/v1/documents/{documentId}", UUID.randomUUID())
+			.header("X-User-Id", "user-123"));
+
+		assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("성공_문서 복구 API는 삭제 문서와 해당 문서 소속 삭제 블록을 함께 복구한다")
+	void restoreDocumentRestoresDocumentAndOwnedDeletedBlocks() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document deletedDocument = saveDeletedDocument(workspace.getId(), "복구 대상 문서", "00000000000000000001");
+		Document otherDocument = saveDocument(workspace.getId(), null, "다른 문서", "00000000000000000002");
+
+		Block deletedTargetBlock = saveDeletedBlock(deletedDocument.getId(), null, "복구 대상 블록",
+			"000000000001000000000000");
+		Block activeTargetBlock = saveBlock(deletedDocument.getId(), null, "활성 블록", "000000000002000000000000");
+		Block deletedOtherBlock = saveDeletedBlock(otherDocument.getId(), null, "다른 문서 블록", "000000000001000000000000");
+
+		mockMvc.perform(patch("/v1/documents/{documentId}/restore", deletedDocument.getId())
+				.header("X-User-Id", "user-123"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.httpStatus").value("OK"))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.code").value(200));
+
+		Document restoredDocument = documentRepository.findById(deletedDocument.getId()).orElseThrow();
+		Block restoredTargetBlock = blockRepository.findById(deletedTargetBlock.getId()).orElseThrow();
+		Block survivedActiveTargetBlock = blockRepository.findById(activeTargetBlock.getId()).orElseThrow();
+		Block survivedOtherBlock = blockRepository.findById(deletedOtherBlock.getId()).orElseThrow();
+
+		assertThat(restoredDocument.getDeletedAt()).isNull();
+		assertThat(restoredTargetBlock.getDeletedAt()).isNull();
+		assertThat(survivedActiveTargetBlock.getDeletedAt()).isNull();
+		assertThat(survivedOtherBlock.getDeletedAt()).isNotNull();
+	}
+
+	@Test
+	@DisplayName("실패_존재하지 않는 문서 복구 요청은 문서 없음 응답을 반환한다")
+	void restoreDocumentReturnsNotFoundWhenDocumentMissing() throws Exception {
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}/restore", UUID.randomUUID())
+			.header("X-User-Id", "user-123"));
+
+		assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("실패_이미 활성 상태인 문서 복구 요청은 문서 없음 응답을 반환한다")
+	void restoreDocumentReturnsNotFoundWhenDocumentAlreadyActive() throws Exception {
+		Workspace workspace = workspace("Docs Root");
+		Document activeDocument = saveDocument(workspace.getId(), null, "활성 문서", "00000000000000000001");
+
+		var result = mockMvc.perform(patch("/v1/documents/{documentId}/restore", activeDocument.getId())
+			.header("X-User-Id", "user-123"));
+
+		assertErrorEnvelope(result, "NOT_FOUND", 9004, "요청한 문서를 찾을 수 없습니다.");
+	}
+
+	private void assertErrorEnvelope(ResultActions result, String httpStatus, int code, String message) throws
+		Exception {
+		result.andExpect(status().is(org.springframework.http.HttpStatus.valueOf(httpStatus).value()))
+			.andExpect(jsonPath("$.httpStatus").value(httpStatus))
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.message").value(message))
+			.andExpect(jsonPath("$.code").value(code))
+			.andExpect(jsonPath("$.data").doesNotExist());
+	}
+
+	private Workspace workspace(String name) {
+		return workspaceRepository.save(Workspace.builder()
+			.id(UUID.randomUUID())
+			.name(name)
+			.build());
+	}
+
+	private Document saveDocument(UUID workspaceId, UUID parentId, String title, String sortKey) {
+		return saveDocument(workspaceId, parentId, title, sortKey, null, null, null, null);
+	}
+
+	private Document saveDocument(
+		UUID workspaceId,
+		UUID parentId,
+		String title,
+		String sortKey,
+		String iconJson,
+		String coverJson,
+		String createdBy,
+		String updatedBy
+	) {
+		return documentRepository.save(Document.builder()
+			.id(UUID.randomUUID())
+			.workspace(workspaceRepository.getReferenceById(workspaceId))
+			.parent(parentId == null ? null : documentRepository.getReferenceById(parentId))
+			.title(title)
+			.sortKey(sortKey)
+			.iconJson(iconJson)
+			.coverJson(coverJson)
+			.createdBy(createdBy)
+			.updatedBy(updatedBy)
+			.build());
+	}
+
+	private Document saveDeletedDocument(UUID workspaceId, String title, String sortKey) {
+		return documentRepository.save(Document.builder()
+			.id(UUID.randomUUID())
+			.workspace(workspaceRepository.getReferenceById(workspaceId))
+			.title(title)
+			.sortKey(sortKey)
+			.deletedAt(LocalDateTime.of(2026, 3, 16, 0, 0))
+			.build());
+	}
+
+	private Block saveBlock(UUID documentId, UUID parentId, String content, String sortKey) {
+		return blockRepository.save(Block.builder()
+			.id(UUID.randomUUID())
+			.document(documentRepository.getReferenceById(documentId))
+			.parent(parentId == null ? null : blockRepository.getReferenceById(parentId))
+			.type(BlockType.TEXT)
+			.content(toContent(content))
+			.sortKey(sortKey)
+			.createdBy("user-123")
+			.updatedBy("user-123")
+			.build());
+	}
+
+	private Block saveDeletedBlock(UUID documentId, UUID parentId, String content, String sortKey) {
+		return blockRepository.save(Block.builder()
+			.id(UUID.randomUUID())
+			.document(documentRepository.getReferenceById(documentId))
+			.parent(parentId == null ? null : blockRepository.getReferenceById(parentId))
+			.type(BlockType.TEXT)
+			.content(toContent(content))
+			.sortKey(sortKey)
+			.createdBy("user-123")
+			.updatedBy("user-123")
+			.deletedAt(LocalDateTime.of(2026, 3, 16, 0, 0))
+			.build());
+	}
+
+	private String toContent(String content) {
+		return "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"%s\",\"marks\":[]}]}".formatted(
+			content);
+	}
+
+	@TestConfiguration
+	static class DocumentDeleteSqlCounterTestConfig {
+
+		@Bean
+		DocumentDeleteSqlCounter documentDeleteSqlCounter() {
+			return new DocumentDeleteSqlCounter();
+		}
+
+		@Bean
+		HibernatePropertiesCustomizer documentDeleteSqlCounterCustomizer(DocumentDeleteSqlCounter counter) {
+			return properties -> properties.put("hibernate.session_factory.statement_inspector", counter);
+		}
+	}
+
+	static class DocumentDeleteSqlCounter implements StatementInspector {
+
+		private final AtomicInteger documentSoftDeleteUpdateCount = new AtomicInteger();
+
+		@Override
+		public String inspect(String sql) {
+			String normalizedSql = sql.toLowerCase(Locale.ROOT);
+			if (normalizedSql.contains("update documents") && normalizedSql.contains("deleted_at")) {
+				documentSoftDeleteUpdateCount.incrementAndGet();
+			}
+			return sql;
+		}
+
+		void reset() {
+			documentSoftDeleteUpdateCount.set(0);
+		}
+
+		int documentSoftDeleteUpdateCount() {
+			return documentSoftDeleteUpdateCount.get();
+		}
+	}
 }

--- a/documents-core/src/main/java/com/documents/service/BlockService.java
+++ b/documents-core/src/main/java/com/documents/service/BlockService.java
@@ -23,4 +23,6 @@ public interface BlockService {
     Block update(UUID blockId, String content, Integer version, String actorId);
 
     void softDeleteAllByDocumentId(UUID documentId, String actorId, LocalDateTime deletedAt);
+
+    void restoreAllByDocumentId(UUID documentId, String actorId, LocalDateTime updatedAt);
 }

--- a/documents-core/src/main/java/com/documents/service/DocumentService.java
+++ b/documents-core/src/main/java/com/documents/service/DocumentService.java
@@ -10,4 +10,5 @@ public interface DocumentService {
     Document getById(UUID documentId);
     Document update(UUID documentId, String title, String iconJson, String coverJson, UUID parentId, String actorId);
     void delete(UUID documentId, String actorId);
+    void restore(UUID documentId, String actorId);
 }

--- a/documents-infrastructure/src/main/java/com/documents/repository/BlockRepository.java
+++ b/documents-infrastructure/src/main/java/com/documents/repository/BlockRepository.java
@@ -68,4 +68,19 @@ public interface BlockRepository extends JpaRepository<Block, UUID> {
             @Param("actorId") String actorId,
             @Param("deletedAt") LocalDateTime deletedAt
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Block b
+            set b.deletedAt = null,
+                b.updatedBy = :actorId,
+                b.updatedAt = :updatedAt
+            where b.document.id = :documentId
+              and b.deletedAt is not null
+            """)
+    void restoreDeletedByDocumentId(
+            @Param("documentId") UUID documentId,
+            @Param("actorId") String actorId,
+            @Param("updatedAt") LocalDateTime updatedAt
+    );
 }

--- a/documents-infrastructure/src/main/java/com/documents/repository/DocumentRepository.java
+++ b/documents-infrastructure/src/main/java/com/documents/repository/DocumentRepository.java
@@ -55,6 +55,18 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
 		""")
 	List<Document> findActiveChildrenByParentIdOrderBySortKey(@Param("parentId") UUID parentId);
 
+	@Query("""
+		select d
+		from Document d
+		where d.parent.id = :parentId
+		  and d.deletedAt is not null
+		order by
+		  d.sortKey asc,
+		  d.createdAt asc,
+		  d.id asc
+		""")
+	List<Document> findDeletedChildrenByParentIdOrderBySortKey(@Param("parentId") UUID parentId);
+
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query("""
 		update Document d
@@ -67,5 +79,20 @@ public interface DocumentRepository extends JpaRepository<Document, UUID> {
 		@Param("documentIds") List<UUID> documentIds,
 		@Param("actorId") String actorId,
 		@Param("deletedAt") LocalDateTime deletedAt
+	);
+
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("""
+		update Document d
+		set d.deletedAt = null,
+		    d.updatedBy = :actorId,
+		    d.updatedAt = :updatedAt
+		where d.id in :documentIds
+		  and d.deletedAt is not null
+		""")
+	int restoreDeletedByIds(
+		@Param("documentIds") List<UUID> documentIds,
+		@Param("actorId") String actorId,
+		@Param("updatedAt") LocalDateTime updatedAt
 	);
 }

--- a/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
@@ -106,6 +106,12 @@ public class BlockServiceImpl implements BlockService {
         blockRepository.softDeleteActiveByDocumentId(documentId, actorId, deletedAt);
     }
 
+    @Override
+    @Transactional
+    public void restoreAllByDocumentId(UUID documentId, String actorId, LocalDateTime updatedAt) {
+        blockRepository.restoreDeletedByDocumentId(documentId, actorId, updatedAt);
+    }
+
     private Document findActiveDocument(UUID documentId) {
         return documentRepository.findByIdAndDeletedAtIsNull(documentId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));

--- a/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
@@ -100,7 +100,14 @@ public class DocumentServiceImpl implements DocumentService {
 	@Override
 	@Transactional
 	public void restore(UUID documentId, String actorId) {
-		findActiveDocument(documentId);
+		Document deletedDocument = findDeletedDocument(documentId);
+		validateParentForRestore(deletedDocument);
+
+		String normalizedActorId = textNormalizer.normalizeNullable(actorId);
+		LocalDateTime restoredAt = LocalDateTime.now();
+		List<UUID> documentIdsToRestore = collectDeletedDocumentTreeIds(deletedDocument);
+
+		documentRepository.restoreDeletedByIds(documentIdsToRestore, normalizedActorId, restoredAt);
 	}
 
 	private Document validateParentForWorkspace(UUID workspaceId, UUID parentId) {
@@ -158,9 +165,33 @@ public class DocumentServiceImpl implements DocumentService {
 		}
 	}
 
+	private void validateParentForRestore(Document document) {
+		if (document.getParentId() == null) {
+			return;
+		}
+
+		Document parentDocument = documentRepository.findById(document.getParentId())
+			.orElseThrow(() -> new BusinessException(BusinessErrorCode.INVALID_REQUEST));
+
+		if (parentDocument.getDeletedAt() != null) {
+			throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+		}
+	}
+
 	private Document findActiveDocument(UUID documentId) {
 		return documentRepository.findByIdAndDeletedAtIsNull(documentId)
 			.orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
+	}
+
+	private Document findDeletedDocument(UUID documentId) {
+		Document document = documentRepository.findById(documentId)
+			.orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
+
+		if (document.getDeletedAt() == null) {
+			throw new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+		}
+
+		return document;
 	}
 
 	private List<UUID> collectActiveDocumentTreeIds(Document rootDocument) {
@@ -175,6 +206,21 @@ public class DocumentServiceImpl implements DocumentService {
 		List<Document> children = documentRepository.findActiveChildrenByParentIdOrderBySortKey(document.getId());
 		for (Document child : children) {
 			collectActiveDocumentTreeIds(child, documentIds);
+		}
+	}
+
+	private List<UUID> collectDeletedDocumentTreeIds(Document rootDocument) {
+		List<UUID> documentIds = new ArrayList<>();
+		collectDeletedDocumentTreeIds(rootDocument, documentIds);
+		return documentIds;
+	}
+
+	private void collectDeletedDocumentTreeIds(Document document, List<UUID> documentIds) {
+		documentIds.add(document.getId());
+
+		List<Document> children = documentRepository.findDeletedChildrenByParentIdOrderBySortKey(document.getId());
+		for (Document child : children) {
+			collectDeletedDocumentTreeIds(child, documentIds);
 		}
 	}
 

--- a/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
@@ -97,6 +97,12 @@ public class DocumentServiceImpl implements DocumentService {
 		}
 	}
 
+	@Override
+	@Transactional
+	public void restore(UUID documentId, String actorId) {
+		findActiveDocument(documentId);
+	}
+
 	private Document validateParentForWorkspace(UUID workspaceId, UUID parentId) {
 		if (parentId == null) {
 			return null;

--- a/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/DocumentServiceImpl.java
@@ -108,6 +108,9 @@ public class DocumentServiceImpl implements DocumentService {
 		List<UUID> documentIdsToRestore = collectDeletedDocumentTreeIds(deletedDocument);
 
 		documentRepository.restoreDeletedByIds(documentIdsToRestore, normalizedActorId, restoredAt);
+		for (UUID currentDocumentId : documentIdsToRestore) {
+			blockService.restoreAllByDocumentId(currentDocumentId, normalizedActorId, restoredAt);
+		}
 	}
 
 	private Document validateParentForWorkspace(UUID workspaceId, UUID parentId) {

--- a/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
@@ -471,6 +471,75 @@ class DocumentServiceImplTest {
 			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
 	}
 
+	@Test
+	@DisplayName("성공_루트 삭제 문서는 부모 검증 없이 복구한다")
+	void restoreRootDeletedDocument() {
+		UUID documentId = UUID.randomUUID();
+		Document deletedDocument = deletedDocument(documentId, UUID.randomUUID(), null, "삭제 문서", "00000000000000000001");
+		when(documentRepository.findById(documentId)).thenReturn(Optional.of(deletedDocument));
+		when(documentRepository.findDeletedChildrenByParentIdOrderBySortKey(documentId)).thenReturn(java.util.List.of());
+		when(textNormalizer.normalizeNullable(" user-456 ")).thenReturn("user-456");
+
+		documentService.restore(documentId, " user-456 ");
+
+		ArgumentCaptor<java.time.LocalDateTime> restoredAtCaptor = ArgumentCaptor.forClass(java.time.LocalDateTime.class);
+		verify(documentRepository).restoreDeletedByIds(eq(java.util.List.of(documentId)), eq("user-456"),
+			restoredAtCaptor.capture());
+	}
+
+	@Test
+	@DisplayName("성공_활성 부모 밑 삭제 자식 문서는 복구한다")
+	void restoreDeletedChildDocumentWhenParentIsActive() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID parentId = UUID.randomUUID();
+		UUID childId = UUID.randomUUID();
+		Document deletedChild = deletedDocument(childId, workspaceId, parentId, "삭제 자식", "00000000000000000002");
+		Document activeParent = document(parentId, workspaceId, null, "활성 부모", "00000000000000000001");
+		when(documentRepository.findById(childId)).thenReturn(Optional.of(deletedChild));
+		when(documentRepository.findById(parentId)).thenReturn(Optional.of(activeParent));
+		when(documentRepository.findDeletedChildrenByParentIdOrderBySortKey(childId)).thenReturn(java.util.List.of());
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+
+		documentService.restore(childId, ACTOR_ID);
+
+		verify(documentRepository).restoreDeletedByIds(eq(java.util.List.of(childId)), eq(ACTOR_ID),
+			any(java.time.LocalDateTime.class));
+	}
+
+	@Test
+	@DisplayName("실패_삭제된 부모 밑 삭제 자식 문서는 단독 복구할 수 없다")
+	void restoreFailsWhenParentIsDeleted() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID parentId = UUID.randomUUID();
+		UUID childId = UUID.randomUUID();
+		Document deletedChild = deletedDocument(childId, workspaceId, parentId, "삭제 자식", "00000000000000000002");
+		Document deletedParent = deletedDocument(parentId, workspaceId, null, "삭제 부모", "00000000000000000001");
+		when(documentRepository.findById(childId)).thenReturn(Optional.of(deletedChild));
+		when(documentRepository.findById(parentId)).thenReturn(Optional.of(deletedParent));
+
+		assertThatThrownBy(() -> documentService.restore(childId, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("잘못된 요청입니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+
+		verify(documentRepository, never()).restoreDeletedByIds(anyList(), any(), any());
+	}
+
+	@Test
+	@DisplayName("실패_활성 문서 복구 요청은 문서 없음 예외를 던진다")
+	void restoreThrowsWhenDocumentIsAlreadyActive() {
+		UUID documentId = UUID.randomUUID();
+		when(documentRepository.findById(documentId))
+			.thenReturn(Optional.of(document(documentId, UUID.randomUUID(), null, "활성 문서", "00000000000000000001")));
+
+		assertThatThrownBy(() -> documentService.restore(documentId, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("요청한 문서를 찾을 수 없습니다.")
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+	}
+
 	private Workspace workspace(UUID workspaceId) {
 		return Workspace.builder()
 			.id(workspaceId)
@@ -494,6 +563,12 @@ class DocumentServiceImplTest {
 
 	private Document parentDocument(UUID documentId, UUID workspaceId) {
 		return document(documentId, workspaceId, null, "부모 문서", "00000000000000000001");
+	}
+
+	private Document deletedDocument(UUID documentId, UUID workspaceId, UUID parentId, String title, String sortKey) {
+		Document document = document(documentId, workspaceId, parentId, title, sortKey);
+		document.setDeletedAt(java.time.LocalDateTime.of(2026, 3, 16, 0, 0));
+		return document;
 	}
 
 }

--- a/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/DocumentServiceImplTest.java
@@ -527,6 +527,25 @@ class DocumentServiceImplTest {
 	}
 
 	@Test
+	@DisplayName("실패_삭제된 부모 밑 삭제 자식 문서 복구 실패 시 블록 복구도 호출하지 않는다")
+	void restoreDoesNotDelegateBlockRestoreWhenParentIsDeleted() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID parentId = UUID.randomUUID();
+		UUID childId = UUID.randomUUID();
+		Document deletedChild = deletedDocument(childId, workspaceId, parentId, "삭제 자식", "00000000000000000002");
+		Document deletedParent = deletedDocument(parentId, workspaceId, null, "삭제 부모", "00000000000000000001");
+		when(documentRepository.findById(childId)).thenReturn(Optional.of(deletedChild));
+		when(documentRepository.findById(parentId)).thenReturn(Optional.of(deletedParent));
+
+		assertThatThrownBy(() -> documentService.restore(childId, ACTOR_ID))
+			.isInstanceOf(BusinessException.class)
+			.extracting("errorCode")
+			.isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+
+		verify(blockService, never()).restoreAllByDocumentId(any(), any(), any());
+	}
+
+	@Test
 	@DisplayName("실패_활성 문서 복구 요청은 문서 없음 예외를 던진다")
 	void restoreThrowsWhenDocumentIsAlreadyActive() {
 		UUID documentId = UUID.randomUUID();
@@ -538,6 +557,49 @@ class DocumentServiceImplTest {
 			.hasMessage("요청한 문서를 찾을 수 없습니다.")
 			.extracting("errorCode")
 			.isEqualTo(BusinessErrorCode.DOCUMENT_NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("성공_하위 문서까지 함께 복구될 때 각 문서의 블록 복구도 함께 호출한다")
+	void restoreDelegatesBlockRestoreForDescendantDocuments() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID rootId = UUID.randomUUID();
+		UUID childId = UUID.randomUUID();
+		Document deletedRoot = deletedDocument(rootId, workspaceId, null, "삭제 루트", "00000000000000000001");
+		Document deletedChild = deletedDocument(childId, workspaceId, rootId, "삭제 자식", "00000000000000000002");
+		when(documentRepository.findById(rootId)).thenReturn(Optional.of(deletedRoot));
+		when(documentRepository.findDeletedChildrenByParentIdOrderBySortKey(rootId)).thenReturn(java.util.List.of(deletedChild));
+		when(documentRepository.findDeletedChildrenByParentIdOrderBySortKey(childId)).thenReturn(java.util.List.of());
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+
+		documentService.restore(rootId, ACTOR_ID);
+
+		ArgumentCaptor<java.time.LocalDateTime> restoredAtCaptor = ArgumentCaptor.forClass(java.time.LocalDateTime.class);
+		verify(documentRepository).restoreDeletedByIds(eq(java.util.List.of(rootId, childId)), eq(ACTOR_ID),
+			restoredAtCaptor.capture());
+		verify(blockService).restoreAllByDocumentId(eq(rootId), eq(ACTOR_ID), eq(restoredAtCaptor.getValue()));
+		verify(blockService).restoreAllByDocumentId(eq(childId), eq(ACTOR_ID), eq(restoredAtCaptor.getValue()));
+	}
+
+	@Test
+	@DisplayName("성공_복구 대상이 아닌 다른 문서 블록은 복구 대상에 포함하지 않는다")
+	void restoreDoesNotDelegateBlockRestoreForOtherDocument() {
+		UUID workspaceId = UUID.randomUUID();
+		UUID rootId = UUID.randomUUID();
+		UUID childId = UUID.randomUUID();
+		UUID otherDocumentId = UUID.randomUUID();
+		Document deletedRoot = deletedDocument(rootId, workspaceId, null, "삭제 루트", "00000000000000000001");
+		Document deletedChild = deletedDocument(childId, workspaceId, rootId, "삭제 자식", "00000000000000000002");
+		when(documentRepository.findById(rootId)).thenReturn(Optional.of(deletedRoot));
+		when(documentRepository.findDeletedChildrenByParentIdOrderBySortKey(rootId)).thenReturn(java.util.List.of(deletedChild));
+		when(documentRepository.findDeletedChildrenByParentIdOrderBySortKey(childId)).thenReturn(java.util.List.of());
+		when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+
+		documentService.restore(rootId, ACTOR_ID);
+
+		verify(blockService).restoreAllByDocumentId(eq(rootId), eq(ACTOR_ID), any(java.time.LocalDateTime.class));
+		verify(blockService).restoreAllByDocumentId(eq(childId), eq(ACTOR_ID), any(java.time.LocalDateTime.class));
+		verify(blockService, never()).restoreAllByDocumentId(eq(otherDocumentId), any(), any());
 	}
 
 	private Workspace workspace(UUID workspaceId) {

--- a/prompts/2026-03-20-document-restore-api.md
+++ b/prompts/2026-03-20-document-restore-api.md
@@ -1,0 +1,37 @@
+# 2026-03-20 문서 복구 API 구현
+
+- 작업 목적: 현재 브랜치에서 진행한 문서 복구 API 구현 내용을 `prompts/` 로그 정책에 맞춰 한 파일로 정리한다.
+- 변경 범위: 문서 복구 API 스켈레톤, 서비스 복구 로직, 문서 소속 블록 복구 연동, WebMvc/서비스/통합 테스트, HTTP 메서드 정책 반영
+- 관련 요구사항: `docs/REQUIREMENTS.md`의 문서 soft delete / restore 정책
+
+## Step 1. 문서 복구 API 스켈레톤 추가
+
+- `DocumentController`에 문서 복구 엔드포인트를 추가했다.
+- `DocumentService` 인터페이스와 `DocumentServiceImpl`에 `restore(UUID documentId, String actorId)` 진입점을 연결했다.
+- 복구 요청은 사용자 식별자 헤더를 받아 서버에서 처리하는 형태로 맞췄다.
+
+## Step 2. 문서 복구 서비스 로직 구현
+
+- 삭제된 문서만 복구 대상으로 조회하도록 복구 진입 로직을 구현했다.
+- 루트 삭제 문서는 부모 검증 없이 복구 가능하도록 처리했다.
+- 삭제된 자식 문서는 부모 문서 상태를 검증한 뒤 복구하도록 했다.
+- 부모 문서도 삭제 상태이면 자식 문서 단독 복구를 막고 `INVALID_REQUEST`로 실패 처리하도록 했다.
+- 복구 시점은 `deletedAt = null`로 되돌리고, `updatedBy`, `updatedAt`을 함께 갱신하도록 repository bulk update를 추가했다.
+
+## Step 3. 하위 문서 및 소속 블록 복구 연동
+
+- 복구 대상 문서의 삭제된 하위 문서를 재귀적으로 수집해 함께 복구하도록 확장했다.
+- `DocumentRepository.restoreDeletedByIds(...)`를 통해 복구 대상 문서들을 한 번에 복구하도록 정리했다.
+- 각 복구 대상 문서마다 `BlockService.restoreAllByDocumentId(...)`를 호출해 소속 삭제 블록도 함께 복구하도록 연결했다.
+- 다른 문서에 속한 블록은 복구 대상에 포함되지 않도록 범위를 제한했다.
+
+## Step 4. 테스트 보강
+
+- WebMvc 테스트에 복구 성공, 문서 없음, 이미 활성 문서, 사용자 헤더 없음 케이스를 추가했다.
+- 서비스 단위 테스트에 루트 문서 복구, 활성 부모 밑 자식 문서 복구, 삭제된 부모 밑 자식 복구 실패, 하위 문서 및 블록 복구 위임 케이스를 추가했다.
+- Boot 통합 테스트에 삭제 문서와 해당 문서 소속 삭제 블록 복구, 다른 문서 블록 보존, 문서 없음, 이미 활성 문서 실패 케이스를 추가했다.
+
+## Step 5. HTTP 메서드 정책 반영
+
+- 초기 구현/테스트 단계 이후 프로젝트 정책에 맞춰 문서 복구 API HTTP 메서드를 `PATCH`에서 `POST /v1/documents/{documentId}/restore`로 정리했다.
+- 복구 API 의미를 "상태 전이 실행"으로 보고 별도 action endpoint 스타일을 따르도록 맞춘 변경이다.


### PR DESCRIPTION
<!--
제목 작성 요령
[${CONVENTION}] ${구현 내용 요약}

CONVENTION 예시
- [FEAT]  : 새로운 기능 추가
- [FIX]   : 버그 수정
- [REFACTOR] : 코드 리팩터링 (기능 변화 X)
- [CHORE] : 빌드/설정/환경 변경
- [DOCS]  : 문서 수정
-->

## 📝 Part (해당되는 것만 체크)

- [x] BE
- [ ] FE
- [ ] Infra
- [x] Docs
- [x] Test

---

## #️⃣ 연관된 이슈

<!--
이슈와 PR를 자동으로 연결하기 위한 영역입니다.
예시:
- closes #17
- fixes #24
여러 개일 경우 쉼표로 구분해서 적어주세요.
-->

closes #23 

---

## 🔎 작업 내용

<!--
무슨 일을 했는지 "한 눈에" 이해할 수 있게 적어주세요.
가능하면 bullet 형식으로 요약해 주세요.
-->

### 1. 주요 변경 사항 요약

- 문서 복구 API 추가 (`PATCH /v1/documents/{documentId}/restore`)
- soft delete된 문서만 복구 대상으로 제한
- 문서 복구 시 해당 문서 트리의 삭제 문서와 각 문서 소속 soft delete된 Block을 함께 복구
- 부모 문서가 삭제 상태인 경우 자식 문서 단독 복구를 제한
- WebMvc / 서비스 단위 / 통합 테스트 추가

### 2. 상세 내용 (선택)

- `documents-api`에는 복구 컨트롤러 메서드를 추가했습니다.
- `documents-core`에는 `DocumentService.restore(...)`, `BlockService.restoreAllByDocumentId(...)` 계약을 추가했습니다.
- `documents-infrastructure`에서는 삭제 문서 조회, 부모 상태 검증, 삭제 하위 문서 수집, 문서 복구, 문서별 Block 복구를 구현했습니다.
- 예외 처리는 기존 `BusinessException`, `BusinessErrorCode`, `GlobalResponse` 흐름을 유지했습니다.
- 현재 구현은 `PATCH /restore` + `200 OK` 응답 기준입니다.

### 3. 프롬프트 경로

- [/prompts/2026-03-20-document-restore-api.md](https://github.com/jho951/Block-server/blob/main/prompts/2026-03-20-document-restore-api.md)

---

## 💬 집중 리뷰 요청

<!--
리뷰어가 어디를 중점적으로 봐야 하는지 알려주세요.
복잡한 로직, 트레이드오프, 고민했던 포인트를 적어주면 리뷰 품질이 올라갑니다.
-->

- 문서 복구 시 하위 문서까지 함께 복구하는 현재 정책이 의도에 맞는지 확인 부탁드립니다.
  - DocumentServiceImpl.java -> [collectDeletedDocumentTreeIds](https://github.com/jho951/Block-server/pull/28/changes#diff-47569d612045c6da04f60bf5ce8b1e8171cb00be301560c2a1fb6ba5c71cf79bR215)
---

## 🧪 테스트 방법

<!--
리뷰어/테스터가 동일하게 재현할 수 있도록, 테스트 방법을 구체적으로 적어주세요.
로컬/스테이징 환경 기준, 실행 커맨드가 있으면 함께 작성해 주세요.
-->

### 1. 로컬 실행 방법

- 프로젝트 루트에서 아래 명령 실행
- `./gradlew --no-daemon :documents-api:test --tests com.documents.api.document.DocumentControllerWebMvcTest :documents-infrastructure:test --tests com.documents.service.DocumentServiceImplTest :documents-boot:test --tests com.documents.api.document.DocumentApiIntegrationTest`

### 2. 테스트 시나리오

- [x] soft delete된 문서 복구 요청 시 성공 응답 반환 확인
- [x] 복구 성공 시 문서의 `deletedAt`이 `null`로 저장되는지 확인
- [x] 복구 성공 시 해당 문서 소속 soft delete된 Block의 `deletedAt`이 `null`로 저장되는지 확인
- [x] 다른 문서에 속한 Block은 복구되지 않는지 확인
- [x] 존재하지 않는 문서 복구 시 `DOCUMENT_NOT_FOUND` 응답/예외 확인
- [x] 이미 활성 상태인 문서 복구 시 `DOCUMENT_NOT_FOUND` 응답/예외 확인
- [x] 부모가 삭제 상태인 자식 문서 단독 복구 실패 확인
- [x] `X-User-Id` 헤더 누락 시 `UNAUTHORIZED` 응답 확인

---

## ✅ PR 체크리스트

<!--
PR 올리기 전에 스스로 한 번 더 점검하는 용도입니다.
팀 컨벤션에 맞게 자유롭게 수정해서 사용하세요.
-->

- [ ] 불필요한 디버그 로그 / 주석 제거
- [ ] breaking change 여부 확인 및 문서화
- [ ] 신규/변경된 기능에 대한 테스트 코드 추가 또는 기존 테스트 통과
- [ ] 로컬에서 주요 시나리오 수동 테스트 완료
- [ ] 관련 문서(노션, README, API 문서 등) 업데이트