### PR TITLE
feat: 블록 이동 및 순서 변경 API 구현

### DIFF
--- a/documents-api/src/main/java/com/documents/api/block/BlockController.java
+++ b/documents-api/src/main/java/com/documents/api/block/BlockController.java
@@ -2,6 +2,7 @@ package com.documents.api.block;
 
 import com.documents.api.block.dto.BlockResponse;
 import com.documents.api.block.dto.CreateBlockRequest;
+import com.documents.api.block.dto.MoveBlockRequest;
 import com.documents.api.block.dto.UpdateBlockRequest;
 import com.documents.api.block.support.BlockJsonCodec;
 import com.documents.api.code.SuccessCode;
@@ -92,6 +93,24 @@ public class BlockController {
             @RequestHeader(USER_ID_HEADER) String userId
     ) {
         blockService.delete(blockId, userId);
+        return ResponseEntity.ok(GlobalResponse.ok());
+    }
+
+    @Operation(summary = "블록 이동")
+    @PostMapping("/blocks/{blockId}/move")
+    public ResponseEntity<GlobalResponse<Void>> moveBlock(
+            @PathVariable("blockId") UUID blockId,
+            @Valid @RequestBody MoveBlockRequest request,
+            @RequestHeader(USER_ID_HEADER) String userId
+    ) {
+        blockService.move(
+                blockId,
+                request.getParentId(),
+                request.getAfterBlockId(),
+                request.getBeforeBlockId(),
+                request.getVersion(),
+                userId
+        );
         return ResponseEntity.ok(GlobalResponse.ok());
     }
 }

--- a/documents-api/src/main/java/com/documents/api/block/dto/MoveBlockRequest.java
+++ b/documents-api/src/main/java/com/documents/api/block/dto/MoveBlockRequest.java
@@ -1,0 +1,28 @@
+package com.documents.api.block.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "블록 이동 요청")
+public class MoveBlockRequest {
+
+    @Schema(description = "이동 대상 부모 블록 ID", nullable = true)
+    private UUID parentId;
+
+    @Schema(description = "같은 형제 집합의 앞 블록 ID", nullable = true)
+    private UUID afterBlockId;
+
+    @Schema(description = "같은 형제 집합의 뒤 블록 ID", nullable = true)
+    private UUID beforeBlockId;
+
+    @NotNull
+    @Schema(description = "클라이언트가 기준으로 삼은 블록 버전", example = "3", nullable = false)
+    private Integer version;
+}

--- a/documents-api/src/test/java/com/documents/api/block/BlockControllerWebMvcTest.java
+++ b/documents-api/src/test/java/com/documents/api/block/BlockControllerWebMvcTest.java
@@ -707,6 +707,164 @@ class BlockControllerWebMvcTest {
         ApiResponseAssertions.assertErrorEnvelope(result, "CONFLICT", 9005, "요청이 현재 리소스 상태와 충돌합니다.");
     }
 
+    @Test
+    @DisplayName("성공_루트로 이동 요청 시 성공 응답을 반환한다")
+    void moveBlockReturnsSuccessEnvelopeForRootMove() throws Exception {
+        UUID blockId = UUID.randomUUID();
+
+        mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": null,
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 3
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("요청 응답 성공"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data").doesNotExist());
+
+        verify(blockService).move(blockId, null, null, null, 3, "user-123");
+    }
+
+    @Test
+    @DisplayName("성공_다른 부모 아래 특정 형제 뒤로 이동 요청 시 전달값을 그대로 서비스에 넘긴다")
+    void moveBlockPassesAnchorsToService() throws Exception {
+        UUID blockId = UUID.randomUUID();
+        UUID parentId = UUID.randomUUID();
+        UUID afterBlockId = UUID.randomUUID();
+
+        mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": "%s",
+                                  "afterBlockId": "%s",
+                                  "beforeBlockId": null,
+                                  "version": 4
+                                }
+                                """.formatted(parentId, afterBlockId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(200));
+
+        verify(blockService).move(blockId, parentId, afterBlockId, null, 4, "user-123");
+    }
+
+    @Test
+    @DisplayName("실패_인증 헤더가 없으면 블록 이동 API는 인증 오류를 반환한다")
+    void moveBlockReturnsUnauthorizedWhenHeaderMissing() throws Exception {
+        UUID blockId = UUID.randomUUID();
+
+        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+                        .contentType("application/json")
+                        .content("""
+                                {
+                                  "parentId": null,
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """));
+
+        ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
+        verify(blockService, never()).move(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("실패_version이 없으면 블록 이동 API는 유효성 검사 오류를 반환한다")
+    void moveBlockReturnsValidationErrorWhenVersionMissing() throws Exception {
+        UUID blockId = UUID.randomUUID();
+
+        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": null,
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null
+                                }
+                                """));
+
+        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
+        verify(blockService, never()).move(any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("실패_존재하지 않는 블록 이동 요청은 블록 없음 응답을 반환한다")
+    void moveBlockReturnsNotFoundWhenBlockMissing() throws Exception {
+        UUID blockId = UUID.randomUUID();
+        doThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND))
+                .when(blockService).move(blockId, null, null, null, 0, "user-123");
+
+        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": null,
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """));
+
+        ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9006, "요청한 블록을 찾을 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("실패_version이 현재 블록 상태와 충돌하면 블록 이동 API는 충돌 응답을 반환한다")
+    void moveBlockReturnsConflictWhenVersionMismatched() throws Exception {
+        UUID blockId = UUID.randomUUID();
+        doThrow(new BusinessException(BusinessErrorCode.CONFLICT))
+                .when(blockService).move(blockId, null, null, null, 0, "user-123");
+
+        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": null,
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """));
+
+        ApiResponseAssertions.assertErrorEnvelope(result, "CONFLICT", 9005, "요청이 현재 리소스 상태와 충돌합니다.");
+    }
+
+    @Test
+    @DisplayName("실패_잘못된 위치 요청이면 블록 이동 API는 잘못된 요청 응답을 반환한다")
+    void moveBlockReturnsBadRequestWhenRequestInvalid() throws Exception {
+        UUID blockId = UUID.randomUUID();
+        doThrow(new BusinessException(BusinessErrorCode.INVALID_REQUEST))
+                .when(blockService).move(blockId, blockId, null, null, 0, "user-123");
+
+        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": "%s",
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """.formatted(blockId)));
+
+        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
+    }
+
     private Block block(UUID blockId, UUID documentId, UUID parentId, String sortKey, int version, String text) {
         Block block = Block.builder()
                 .id(blockId)

--- a/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
@@ -406,6 +406,332 @@ class BlockApiIntegrationTest {
     }
 
     @Test
+    @DisplayName("성공_루트 블록을 다른 루트 위치로 재정렬하면 sortKey와 updatedBy와 version이 변경된다")
+    void moveRootBlockReordersAmongRootBlocks() throws Exception {
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
+                .id(UUID.randomUUID())
+                .name("Docs Root")
+                .build());
+        Document document = documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title("문서")
+                .sortKey("00000000000000000001")
+                .build());
+        Block first = saveBlock(document, null, "첫 블록", "000000000001000000000000");
+        Block moved = saveBlock(document, null, "이동 대상", "000000000002000000000000");
+        Block third = saveBlock(document, null, "셋째 블록", "000000000003000000000000");
+
+        mockMvc.perform(post("/v1/blocks/{blockId}/move", moved.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-456")
+                        .content("""
+                                {
+                                  "parentId": null,
+                                  "afterBlockId": "%s",
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """.formatted(third.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(200));
+
+        Block reloaded = blockRepository.findById(moved.getId()).orElseThrow();
+        assertThat(reloaded.getParentId()).isNull();
+        assertThat(reloaded.getSortKey()).isEqualTo("000000000004000000000000");
+        assertThat(reloaded.getUpdatedBy()).isEqualTo("user-456");
+        assertThat(reloaded.getVersion()).isEqualTo(1);
+        assertThat(blockRepository.findById(first.getId()).orElseThrow().getSortKey())
+                .isEqualTo("000000000001000000000000");
+    }
+
+    @Test
+    @DisplayName("성공_블록을 다른 부모 블록 아래로 이동하면 parentId와 sortKey가 함께 변경된다")
+    void moveBlockToAnotherParent() throws Exception {
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
+                .id(UUID.randomUUID())
+                .name("Docs Root")
+                .build());
+        Document document = documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title("문서")
+                .sortKey("00000000000000000001")
+                .build());
+        Block parent = saveBlock(document, null, "대상 부모", "000000000001000000000000");
+        saveBlock(document, parent, "기존 자식", "000000000001000000000000");
+        Block moved = saveBlock(document, null, "이동 대상", "000000000002000000000000");
+
+        mockMvc.perform(post("/v1/blocks/{blockId}/move", moved.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-456")
+                        .content("""
+                                {
+                                  "parentId": "%s",
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """.formatted(parent.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(200));
+
+        Block reloaded = blockRepository.findById(moved.getId()).orElseThrow();
+        assertThat(reloaded.getParentId()).isEqualTo(parent.getId());
+        assertThat(reloaded.getSortKey()).isEqualTo("000000000002000000000000");
+        assertThat(reloaded.getUpdatedBy()).isEqualTo("user-456");
+        assertThat(reloaded.getVersion()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("성공_same parent 내 afterBlockId 기준 이동이 반영된다")
+    void moveBlockWithinSameParentUsingAfterAnchor() throws Exception {
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
+                .id(UUID.randomUUID())
+                .name("Docs Root")
+                .build());
+        Document document = documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title("문서")
+                .sortKey("00000000000000000001")
+                .build());
+        Block parent = saveBlock(document, null, "부모", "000000000001000000000000");
+        Block first = saveBlock(document, parent, "첫 자식", "000000000001000000000000");
+        Block second = saveBlock(document, parent, "둘째 자식", "000000000002000000000000");
+        Block moved = saveBlock(document, parent, "이동 대상", "000000000003000000000000");
+
+        mockMvc.perform(post("/v1/blocks/{blockId}/move", moved.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-456")
+                        .content("""
+                                {
+                                  "parentId": "%s",
+                                  "afterBlockId": "%s",
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """.formatted(parent.getId(), first.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(200));
+
+        Block reloaded = blockRepository.findById(moved.getId()).orElseThrow();
+        assertThat(reloaded.getParentId()).isEqualTo(parent.getId());
+        assertThat(reloaded.getSortKey()).isEqualTo("000000000001I00000000000");
+        assertThat(reloaded.getUpdatedBy()).isEqualTo("user-456");
+        assertThat(blockRepository.findById(second.getId()).orElseThrow().getSortKey())
+                .isEqualTo("000000000002000000000000");
+    }
+
+    @Test
+    @DisplayName("실패_존재하지 않는 블록 이동은 블록 없음 응답을 반환한다")
+    void moveBlockReturnsNotFoundWhenBlockMissing() throws Exception {
+        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", UUID.randomUUID())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": null,
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """));
+
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.code").value(9006))
+                .andExpect(jsonPath("$.message").value("요청한 블록을 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("실패_삭제된 블록 이동은 블록 없음 응답을 반환한다")
+    void moveBlockReturnsNotFoundWhenBlockDeleted() throws Exception {
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
+                .id(UUID.randomUUID())
+                .name("Docs Root")
+                .build());
+        Document document = documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title("문서")
+                .sortKey("00000000000000000001")
+                .build());
+        Block deleted = blockRepository.save(Block.builder()
+                .id(UUID.randomUUID())
+                .document(document)
+                .type(BlockType.TEXT)
+                .content(toContent("삭제 블록"))
+                .sortKey("000000000001000000000000")
+                .createdBy("user-123")
+                .updatedBy("user-123")
+                .deletedAt(java.time.LocalDateTime.of(2026, 3, 20, 0, 0))
+                .build());
+
+        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", deleted.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": null,
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """));
+
+        result.andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.code").value(9006))
+                .andExpect(jsonPath("$.message").value("요청한 블록을 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("실패_블록 이동 API에 낡은 version이 오면 충돌 응답을 반환한다")
+    void moveBlockReturnsConflictWhenVersionMismatched() throws Exception {
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
+                .id(UUID.randomUUID())
+                .name("Docs Root")
+                .build());
+        Document document = documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title("문서")
+                .sortKey("00000000000000000001")
+                .build());
+        Block block = saveBlock(document, null, "이동 대상", "000000000001000000000000");
+        block.setContent(toContent("다른 사용자 수정"));
+        blockRepository.save(block);
+
+        mockMvc.perform(post("/v1/blocks/{blockId}/move", block.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-456")
+                        .content("""
+                                {
+                                  "parentId": null,
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.httpStatus").value("CONFLICT"))
+                .andExpect(jsonPath("$.code").value(9005))
+                .andExpect(jsonPath("$.message").value("요청이 현재 리소스 상태와 충돌합니다."));
+    }
+
+    @Test
+    @DisplayName("실패_자기 자신을 부모로 지정하면 잘못된 요청 응답을 반환한다")
+    void moveBlockReturnsBadRequestWhenParentIsSelf() throws Exception {
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
+                .id(UUID.randomUUID())
+                .name("Docs Root")
+                .build());
+        Document document = documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title("문서")
+                .sortKey("00000000000000000001")
+                .build());
+        Block block = saveBlock(document, null, "이동 대상", "000000000001000000000000");
+
+        mockMvc.perform(post("/v1/blocks/{blockId}/move", block.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": "%s",
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """.formatted(block.getId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.code").value(9015))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+    }
+
+    @Test
+    @DisplayName("실패_하위 블록을 부모로 지정하면 잘못된 요청 응답을 반환한다")
+    void moveBlockReturnsBadRequestWhenParentIsDescendant() throws Exception {
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
+                .id(UUID.randomUUID())
+                .name("Docs Root")
+                .build());
+        Document document = documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title("문서")
+                .sortKey("00000000000000000001")
+                .build());
+        Block root = saveBlock(document, null, "루트", "000000000001000000000000");
+        Block child = saveBlock(document, root, "자식", "000000000001000000000000");
+
+        mockMvc.perform(post("/v1/blocks/{blockId}/move", root.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": "%s",
+                                  "afterBlockId": null,
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """.formatted(child.getId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.code").value(9015))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+    }
+
+    @Test
+    @DisplayName("실패_다른 문서의 블록을 부모나 anchor로 사용하면 잘못된 요청 응답을 반환한다")
+    void moveBlockReturnsBadRequestWhenParentOrAnchorBelongsToOtherDocument() throws Exception {
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
+                .id(UUID.randomUUID())
+                .name("Docs Root")
+                .build());
+        Document sourceDocument = documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title("원본 문서")
+                .sortKey("00000000000000000001")
+                .build());
+        Document otherDocument = documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title("다른 문서")
+                .sortKey("00000000000000000002")
+                .build());
+        Block moved = saveBlock(sourceDocument, null, "이동 대상", "000000000001000000000000");
+        Block otherParent = saveBlock(otherDocument, null, "다른 부모", "000000000001000000000000");
+        Block otherAnchor = saveBlock(otherDocument, null, "다른 anchor", "000000000002000000000000");
+
+        mockMvc.perform(post("/v1/blocks/{blockId}/move", moved.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "parentId": "%s",
+                                  "afterBlockId": "%s",
+                                  "beforeBlockId": null,
+                                  "version": 0
+                                }
+                                """.formatted(otherParent.getId(), otherAnchor.getId())))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
+                .andExpect(jsonPath("$.code").value(9015))
+                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
+    }
+
+    @Test
     @DisplayName("실패_블록 생성 API에 허용되지 않은 mark가 오면 유효성 검사 오류를 반환한다")
     void createBlockRejectsUnsupportedMarkType() throws Exception {
         Workspace workspace = workspaceRepository.save(Workspace.builder()

--- a/documents-core/src/main/java/com/documents/service/BlockService.java
+++ b/documents-core/src/main/java/com/documents/service/BlockService.java
@@ -22,6 +22,8 @@ public interface BlockService {
 
     Block update(UUID blockId, String content, Integer version, String actorId);
 
+    void move(UUID blockId, UUID parentId, UUID afterBlockId, UUID beforeBlockId, Integer version, String actorId);
+
     void delete(UUID blockId, String actorId);
 
     void softDeleteAllByDocumentId(UUID documentId, String actorId, LocalDateTime deletedAt);

--- a/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
@@ -3,6 +3,7 @@ package com.documents.service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -103,6 +104,38 @@ public class BlockServiceImpl implements BlockService {
 
     @Override
     @Transactional
+    public void move(UUID blockId, UUID parentId, UUID afterBlockId, UUID beforeBlockId, Integer version, String actorId) {
+        Block block = findActiveBlock(blockId);
+
+        if (!block.getVersion().equals(version)) {
+            throw new BusinessException(BusinessErrorCode.CONFLICT);
+        }
+
+        Block targetParentBlock = findValidParentForMove(block, parentId);
+        List<Block> siblings = blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(block.getDocumentId(), parentId);
+        List<Block> targetSiblings = siblings.stream()
+                .filter(sibling -> !blockId.equals(sibling.getId()))
+                .toList();
+
+        String nextSortKey = generateSortKey(targetSiblings, afterBlockId, beforeBlockId);
+
+        if (Objects.equals(block.getParentId(), parentId)
+                && Objects.equals(block.getSortKey(), nextSortKey)) {
+            return;
+        }
+
+        String normalizedActorId = textNormalizer.normalizeNullable(actorId);
+        if (normalizedActorId == null) {
+            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+        }
+
+        block.setParent(targetParentBlock);
+        block.setSortKey(nextSortKey);
+        block.setUpdatedBy(normalizedActorId);
+    }
+
+    @Override
+    @Transactional
     public void delete(UUID blockId, String actorId) {
         String normalizedActorId = textNormalizer.normalizeNullable(actorId);
         LocalDateTime deletedAt = LocalDateTime.now();
@@ -160,6 +193,24 @@ public class BlockServiceImpl implements BlockService {
         return parentBlock;
     }
 
+    private Block findValidParentForMove(Block block, UUID parentId) {
+        if (Objects.equals(block.getId(), parentId)) {
+            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+        }
+
+        if (parentId == null) {
+            return null;
+        }
+
+        Block parentBlock = findActiveBlock(parentId);
+        if (!block.getDocumentId().equals(parentBlock.getDocumentId())) {
+            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+        }
+
+        validateNoCycle(block.getId(), parentBlock);
+        return parentBlock;
+    }
+
     private void validateDepth(Block parentBlock) {
         int depth = 1;
         Block current = parentBlock;
@@ -167,6 +218,18 @@ public class BlockServiceImpl implements BlockService {
         while (current != null) {
             depth++;
             if (depth > MAX_BLOCK_DEPTH) {
+                throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+            }
+
+            current = current.getParentId() == null ? null : findActiveBlock(current.getParentId());
+        }
+    }
+
+    private void validateNoCycle(UUID blockId, Block parentBlock) {
+        Block current = parentBlock;
+
+        while (current != null) {
+            if (blockId.equals(current.getId())) {
                 throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
             }
 

--- a/documents-infrastructure/src/test/java/com/documents/service/BlockServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/BlockServiceImplTest.java
@@ -274,6 +274,303 @@ class BlockServiceImplTest {
     }
 
     @Test
+    @DisplayName("성공_parentId와 anchor가 모두 null이면 루트 형제 집합의 마지막 위치로 이동한다")
+    void moveMovesBlockToDocumentRootLastPosition() {
+        UUID documentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        Block block = block(documentId, UUID.randomUUID(), "000000000001000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+        block.setUpdatedBy("old-user");
+        Block sibling = block(documentId, null, "000000000002000000000000");
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, null))
+                .thenReturn(List.of(sibling));
+        when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+
+        blockService.move(blockId, null, null, null, 1, ACTOR_ID);
+
+        assertThat(block.getParentId()).isNull();
+        assertThat(block.getSortKey()).isEqualTo("000000000003000000000000");
+        assertThat(block.getUpdatedBy()).isEqualTo(ACTOR_ID);
+    }
+
+    @Test
+    @DisplayName("성공_같은 부모에서 afterBlockId 기준으로 재정렬하면 새 sortKey와 updatedBy를 반영한다")
+    void moveReordersWithinSameParent() {
+        UUID documentId = UUID.randomUUID();
+        UUID parentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        UUID afterBlockId = UUID.randomUUID();
+        Block block = block(documentId, parentId, "000000000003000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+        block.setUpdatedBy("old-user");
+        Block parent = parentBlock(parentId, documentId);
+        Block afterBlock = block(documentId, parentId, "000000000001000000000000");
+        afterBlock.setId(afterBlockId);
+        Block nextBlock = block(documentId, parentId, "000000000002000000000000");
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.of(parent));
+        when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, parentId))
+                .thenReturn(List.of(afterBlock, nextBlock, block));
+        when(textNormalizer.normalizeNullable(ACTOR_ID)).thenReturn(ACTOR_ID);
+
+        blockService.move(blockId, parentId, afterBlockId, null, 1, ACTOR_ID);
+
+        assertThat(block.getParentId()).isEqualTo(parentId);
+        assertThat(block.getSortKey()).isEqualTo("000000000001I00000000000");
+        assertThat(block.getUpdatedBy()).isEqualTo(ACTOR_ID);
+    }
+
+    @Test
+    @DisplayName("성공_다른 부모로 이동하면 parentId와 sortKey와 updatedBy를 함께 갱신한다")
+    void moveUpdatesParentSortKeyAndUpdatedBy() {
+        UUID documentId = UUID.randomUUID();
+        UUID currentParentId = UUID.randomUUID();
+        UUID targetParentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        Block block = block(documentId, currentParentId, "000000000003000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+        block.setUpdatedBy("old-user");
+        Block targetParent = parentBlock(targetParentId, documentId);
+        Block sibling = block(documentId, targetParentId, "000000000001000000000000");
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findByIdAndDeletedAtIsNull(targetParentId)).thenReturn(Optional.of(targetParent));
+        when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, targetParentId))
+                .thenReturn(List.of(sibling));
+        when(textNormalizer.normalizeNullable(" user-456 ")).thenReturn("user-456");
+
+        blockService.move(blockId, targetParentId, null, null, 1, " user-456 ");
+
+        assertThat(block.getParentId()).isEqualTo(targetParentId);
+        assertThat(block.getSortKey()).isEqualTo("000000000002000000000000");
+        assertThat(block.getUpdatedBy()).isEqualTo("user-456");
+    }
+
+    @Test
+    @DisplayName("성공_요청 위치가 현재 위치와 같으면 no-op으로 성공 처리하고 변경하지 않는다")
+    void moveDoesNothingWhenTargetLocationIsSame() {
+        UUID documentId = UUID.randomUUID();
+        UUID parentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        Block block = block(documentId, parentId, "000000000001000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+        block.setUpdatedBy("old-user");
+        Block parent = parentBlock(parentId, documentId);
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.of(parent));
+        when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, parentId))
+                .thenReturn(List.of(block));
+
+        blockService.move(blockId, parentId, null, null, 1, ACTOR_ID);
+
+        assertThat(block.getParentId()).isEqualTo(parentId);
+        assertThat(block.getSortKey()).isEqualTo("000000000001000000000000");
+        assertThat(block.getUpdatedBy()).isEqualTo("old-user");
+        verify(textNormalizer, never()).normalizeNullable(ACTOR_ID);
+    }
+
+    @Test
+    @DisplayName("실패_이동 대상 블록이 없으면 블록 없음 예외를 던진다")
+    void moveThrowsWhenBlockMissing() {
+        UUID blockId = UUID.randomUUID();
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> blockService.move(blockId, null, null, null, 0, ACTOR_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("요청한 블록을 찾을 수 없습니다.")
+                .extracting("errorCode")
+                .isEqualTo(BusinessErrorCode.BLOCK_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패_version이 현재 블록 version과 다르면 충돌 예외를 던진다")
+    void moveThrowsWhenVersionMismatched() {
+        UUID documentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        Block block = block(documentId, null, "000000000001000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+
+        assertThatThrownBy(() -> blockService.move(blockId, null, null, null, 0, ACTOR_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("요청이 현재 리소스 상태와 충돌합니다.")
+                .extracting("errorCode")
+                .isEqualTo(BusinessErrorCode.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("실패_parentId가 존재하지 않으면 블록 없음 예외를 던진다")
+    void moveThrowsWhenParentMissing() {
+        UUID documentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        UUID parentId = UUID.randomUUID();
+        Block block = block(documentId, null, "000000000001000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> blockService.move(blockId, parentId, null, null, 1, ACTOR_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("요청한 블록을 찾을 수 없습니다.")
+                .extracting("errorCode")
+                .isEqualTo(BusinessErrorCode.BLOCK_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("실패_대상 부모가 다른 문서 소속 블록이면 잘못된 요청 예외를 던진다")
+    void moveThrowsWhenParentBelongsToOtherDocument() {
+        UUID documentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        UUID parentId = UUID.randomUUID();
+        Block block = block(documentId, null, "000000000001000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+        Block otherDocumentParent = parentBlock(parentId, UUID.randomUUID());
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.of(otherDocumentParent));
+
+        assertThatThrownBy(() -> blockService.move(blockId, parentId, null, null, 1, ACTOR_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("잘못된 요청입니다.")
+                .extracting("errorCode")
+                .isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    @DisplayName("실패_자기 자신을 부모로 지정하면 잘못된 요청 예외를 던진다")
+    void moveThrowsWhenParentIsSelf() {
+        UUID documentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        Block block = block(documentId, null, "000000000001000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+
+        assertThatThrownBy(() -> blockService.move(blockId, blockId, null, null, 1, ACTOR_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    @DisplayName("실패_자기 하위 블록을 부모로 지정하면 순환 이동 예외를 던진다")
+    void moveThrowsWhenCycleDetected() {
+        UUID documentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        UUID childId = UUID.randomUUID();
+        Block block = block(documentId, null, "000000000001000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+        Block child = block(documentId, blockId, "000000000002000000000000");
+        child.setId(childId);
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findByIdAndDeletedAtIsNull(childId)).thenReturn(Optional.of(child));
+
+        assertThatThrownBy(() -> blockService.move(blockId, childId, null, null, 1, ACTOR_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    @DisplayName("실패_afterBlockId가 대상 부모의 형제가 아니면 잘못된 요청 예외를 던진다")
+    void moveThrowsWhenAfterBlockIsNotSibling() {
+        UUID documentId = UUID.randomUUID();
+        UUID parentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        Block block = block(documentId, null, "000000000003000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+        Block parent = parentBlock(parentId, documentId);
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.of(parent));
+        when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, parentId))
+                .thenReturn(List.of());
+
+        assertThatThrownBy(() -> blockService.move(blockId, parentId, UUID.randomUUID(), null, 1, ACTOR_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("잘못된 요청입니다.")
+                .extracting("errorCode")
+                .isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    @DisplayName("실패_afterBlockId와 beforeBlockId가 같은 삽입 간격을 가리키지 않으면 잘못된 요청 예외를 던진다")
+    void moveThrowsWhenAnchorsAreContradictory() {
+        UUID documentId = UUID.randomUUID();
+        UUID parentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        UUID afterBlockId = UUID.randomUUID();
+        UUID beforeBlockId = UUID.randomUUID();
+        Block block = block(documentId, null, "000000000009000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+        Block parent = parentBlock(parentId, documentId);
+        Block afterBlock = block(documentId, parentId, "000000000001000000000000");
+        afterBlock.setId(afterBlockId);
+        Block middleBlock = block(documentId, parentId, "000000000002000000000000");
+        Block beforeBlock = block(documentId, parentId, "000000000003000000000000");
+        beforeBlock.setId(beforeBlockId);
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.of(parent));
+        when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, parentId))
+                .thenReturn(List.of(afterBlock, middleBlock, beforeBlock));
+
+        assertThatThrownBy(() -> blockService.move(blockId, parentId, afterBlockId, beforeBlockId, 1, ACTOR_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("잘못된 요청입니다.")
+                .extracting("errorCode")
+                .isEqualTo(BusinessErrorCode.INVALID_REQUEST);
+    }
+
+    @Test
+    @DisplayName("실패_sort key gap이 부족하면 재정렬 필요 예외를 던진다")
+    void moveThrowsWhenSortKeySpaceExhausted() {
+        UUID documentId = UUID.randomUUID();
+        UUID parentId = UUID.randomUUID();
+        UUID blockId = UUID.randomUUID();
+        UUID afterBlockId = UUID.randomUUID();
+        UUID beforeBlockId = UUID.randomUUID();
+        Block block = block(documentId, null, "000000000009000000000000");
+        block.setId(blockId);
+        block.setVersion(1);
+        Block parent = parentBlock(parentId, documentId);
+        Block afterBlock = block(documentId, parentId, "000000000001000000000000");
+        afterBlock.setId(afterBlockId);
+        Block beforeBlock = block(documentId, parentId, "000000000001000000000001");
+        beforeBlock.setId(beforeBlockId);
+
+        when(blockRepository.findByIdAndDeletedAtIsNull(blockId)).thenReturn(Optional.of(block));
+        when(blockRepository.findByIdAndDeletedAtIsNull(parentId)).thenReturn(Optional.of(parent));
+        when(blockRepository.findActiveByDocumentIdAndParentIdOrderBySortKey(documentId, parentId))
+                .thenReturn(List.of(afterBlock, beforeBlock));
+
+        assertThatThrownBy(() -> blockService.move(blockId, parentId, afterBlockId, beforeBlockId, 1, ACTOR_ID))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage("정렬 키 공간이 부족하여 재정렬이 필요합니다.")
+                .extracting("errorCode")
+                .isEqualTo(BusinessErrorCode.SORT_KEY_REBALANCE_REQUIRED);
+    }
+
+    @Test
     @DisplayName("성공_블록 삭제 시 활성 하위 블록까지 같은 시각으로 bulk soft delete 처리한다")
     void deleteSoftDeletesDescendantBlocks() {
         UUID documentId = UUID.randomUUID();

--- a/prompts/2026-03-21-block-move-api.md
+++ b/prompts/2026-03-21-block-move-api.md
@@ -1,0 +1,52 @@
+# 2026-03-21 블록 move API 구현
+
+- 작업 목적: 블록 이동 및 순서 변경 API를 현재 멀티모듈 구조와 AGENTS 규칙에 맞춰 구현하고 검증 결과를 기록한다.
+- 변경 범위: 블록 move 요청 DTO, 컨트롤러 엔드포인트, 서비스 계약, 서비스 이동 로직, WebMvc 테스트, 서비스 단위 테스트, Boot 통합 테스트
+- 관련 요구사항: `docs/REQUIREMENTS.md`의 블록 이동 / 순서 변경, `docs/decisions/011-separate-block-update-from-move-api.md`
+
+## Step 1. 웹 계층 계약 추가
+
+- `documents-api`에 `MoveBlockRequest`를 추가하고 `POST /v1/blocks/{blockId}/move` 엔드포인트를 연결했다.
+- 요청 필드는 `parentId`, `afterBlockId`, `beforeBlockId`, `version`으로 고정했다.
+- 응답은 기존 move 계열 정책과 동일하게 `200 OK`와 `GlobalResponse.ok()`로 유지했다.
+
+## Step 2. WebMvc 테스트 보강
+
+- `BlockControllerWebMvcTest`에 루트 이동 성공, 다른 부모 아래 after anchor 이동 성공, 인증 헤더 누락, version 누락, `BLOCK_NOT_FOUND`, `CONFLICT`, `INVALID_REQUEST` 케이스를 추가했다.
+- 서비스 구현 전 단계에서 웹 계층 계약과 예외 매핑을 먼저 고정했다.
+
+## Step 3. 서비스 이동 로직 구현
+
+- `BlockService`에 `move(UUID blockId, UUID parentId, UUID afterBlockId, UUID beforeBlockId, Integer version, String actorId)` 계약을 추가했다.
+- `BlockServiceImpl`에 활성 블록 조회, version 충돌 검증, 같은 문서 부모 검증, 자기 자신 부모 지정 금지, 하위 블록 순환 이동 금지, anchor 기반 `sortKey` 계산, no-op 허용, `updatedBy` 갱신 로직을 구현했다.
+- 정렬 키 계산은 기존 `OrderedSortKeyGenerator`를 재사용하고, gap 고갈은 `SORT_KEY_REBALANCE_REQUIRED`로 변환했다.
+
+## Step 4. 서비스 단위 테스트 추가
+
+- `BlockServiceImplTest`에 루트 이동, 같은 부모 내 reorder, 다른 부모 이동, no-op, 블록 없음, version 충돌, 부모 없음, 다른 문서 부모, 자기 자신 부모, 하위 블록 부모, 잘못된 anchor, 정렬 키 공간 부족 케이스를 추가했다.
+- 구현 규칙이 테스트로 먼저 고정되도록 성공 케이스 후 실패 케이스 순서로 정리했다.
+
+## Step 5. 통합 테스트 추가
+
+- `BlockApiIntegrationTest`에 실제 HTTP -> Controller -> Service -> JPA 흐름을 검증하는 이동 시나리오를 추가했다.
+- 루트 재정렬, 다른 부모 이동, same parent `afterBlockId` 이동, 없는 블록, 삭제된 블록, 낡은 version, 자기 자신 부모, 하위 블록 부모, 다른 문서 부모/anchor 케이스를 검증했다.
+
+## Step 6. 테스트 실행 결과
+
+- 실행 명령:
+  - `./gradlew --no-daemon :documents-api:test --tests com.documents.api.block.BlockControllerWebMvcTest`
+  - `./gradlew --no-daemon :documents-infrastructure:test --tests com.documents.service.BlockServiceImplTest`
+  - `./gradlew --no-daemon :documents-api:test --tests com.documents.api.block.BlockControllerWebMvcTest :documents-infrastructure:test --tests com.documents.service.BlockServiceImplTest :documents-boot:test --tests com.documents.api.block.BlockApiIntegrationTest`
+- 결과:
+  - `BUILD SUCCESSFUL`
+  - WebMvc, 서비스 단위, Boot 통합 테스트 모두 통과
+
+## Step 7. REQUIREMENTS 반영 여부
+
+- 반영하지 않음
+- `docs/REQUIREMENTS.md`에 이미 `POST /v1/blocks/{blockId}/move`, `parentId`, `afterBlockId`, `beforeBlockId`, `version`, `sortKey` 갱신, `updatedBy`/`version` 갱신 정책이 정의되어 있어 이번 작업은 기존 요구사항 범위 안의 구현으로 판단했다.
+
+## Step 8. 관련 문서 경로
+
+- ADR: `docs/decisions/011-separate-block-update-from-move-api.md`
+- Explainer: `prompts/explainers/ordered-sortkey-generator.md`


### PR DESCRIPTION
<!--
제목 작성 요령
[${CONVENTION}] ${구현 내용 요약}

CONVENTION 예시
- [FEAT]  : 새로운 기능 추가
- [FIX]   : 버그 수정
- [REFACTOR] : 코드 리팩터링 (기능 변화 X)
- [CHORE] : 빌드/설정/환경 변경
- [DOCS]  : 문서 수정
-->

## 📝 Part (해당되는 것만 체크)

- [x] BE
- [ ] FE
- [ ] Infra
- [x] Docs
- [x] Test

---

## #️⃣ 연관된 이슈

<!--
이슈와 PR를 자동으로 연결하기 위한 영역입니다.
예시:
- closes #17
- fixes #24
여러 개일 경우 쉼표로 구분해서 적어주세요.
-->

closes #34 

---

## 🔎 작업 내용

<!--
무슨 일을 했는지 "한 눈에" 이해할 수 있게 적어주세요.
가능하면 bullet 형식으로 요약해 주세요.
-->

### 1. 주요 변경 사항 요약

- 블록 이동 전용 API `POST /v1/blocks/{blockId}/move` 추가
- 블록 이동 요청 DTO `MoveBlockRequest` 추가
- `BlockService`, `BlockServiceImpl`에 블록 이동/순서 변경 로직 추가
- 블록 이동 시 부모 변경, 같은 부모 내 reorder, `sortKey` 재계산, `version` 충돌 검증 반영
- WebMvc 테스트, 서비스 단위 테스트, Boot 통합 테스트 추가

### 2. 상세 내용 (선택)

- 블록 수정 API와 분리된 이동 API로 구조 변경 책임을 분리했습니다.
- 요청 필드는 `parentId`, `afterBlockId`, `beforeBlockId`, `version` 으로 고정했습니다.
- 이동 대상 블록은 활성 블록만 허용하고, `version` 불일치 시 `409 Conflict`를 반환합니다.
- `parentId`가 있으면 같은 문서 소속 활성 블록인지 검증합니다.
- 자기 자신을 부모로 지정하거나 하위 블록을 부모로 지정하는 순환 이동은 `400 Bad Request`로 처리합니다.
- `afterBlockId`, `beforeBlockId`는 대상 부모 아래 활성 형제 집합 기준으로 검증합니다.
- 정렬 키 계산은 기존 `OrderedSortKeyGenerator`를 재사용했고, gap 부족 시 `SORT_KEY_REBALANCE_REQUIRED`로 변환했습니다.
- 동일 위치 요청은 no-op 성공으로 처리합니다.

요청 예시:
```json
{
  "parentId": "new-parent-block-id",
  "afterBlockId": "blk-a",
  "beforeBlockId": null,
  "version": 0
}
```

### 3. 프롬프트 경로

- [/prompts/2026-03-21-block-move-api.md](https://github.com/jho951/Block-server/blob/main/prompts/2026-03-21-block-move-api.md)

### 4. 참조 문서 경로 (ADR, discussions, roadMap ...)

- [/docs/decisions/011-separate-block-update-from-move-api.md](https://github.com/jho951/Block-server/blob/main/docs/decisions/011-separate-block-update-from-move-api.md)
- [/prompts/explainers/ordered-sortkey-generator.md](https://github.com/jho951/Block-server/blob/main/prompts/explainers/ordered-sortkey-generator.md)
- [/docs/REQUIREMENTS.md](https://github.com/jho951/Block-server/blob/main/docs/REQUIREMENTS.md)

---

## 💬 집중 리뷰 요청

<!--
리뷰어가 어디를 중점적으로 봐야 하는지 알려주세요.
복잡한 로직, 트레이드오프, 고민했던 포인트를 적어주면 리뷰 품질이 올라갑니다.
-->

- `BlockServiceImpl.move(...)`의 검증 로직과 `sortKey` 계산 방식이 요구사항에 맞는지 확인부탁드립니다!

---

## 🧪 테스트 방법

<!--
리뷰어/테스터가 동일하게 재현할 수 있도록, 테스트 방법을 구체적으로 적어주세요.
로컬/스테이징 환경 기준, 실행 커맨드가 있으면 함께 작성해 주세요.
-->

### 1. 로컬 실행 방법
- 필요 시 ./gradlew :documents-boot:bootRun 실행
- 테스트만 확인할 경우 아래 명령 실행
  - ./gradlew --no-daemon :documents-api:test --tests com.documents.api.block.BlockControllerWebMvcTest
  - ./gradlew --no-daemon :documents-infrastructure:test --tests com.documents.service.BlockServiceImplTest
  - ./gradlew --no-daemon :documents-api:test --tests com.documents.api.block.BlockControllerWebMvcTest :documents-infrastructure:test --tests com.documents.service.BlockServiceImplTest :documents-boot:test --tests com.documents.api.block.BlockApiIntegrationTest

### 2. 테스트 시나리오
- [x] POST /v1/blocks/{blockId}/move 호출 시 루트 이동이 정상 반영되는지 확인
- [x]  같은 부모 아래 afterBlockId 기준 reorder 시 sortKey가 재계산되는지 확인
- [x]  다른 부모 블록 아래로 이동 시 parentId, sortKey, updatedBy, version이 갱신되는지 확인
- [x]  존재하지 않는 블록 이동 시 404 응답 확인
- [x]  삭제된 블록 이동 시 404 응답 확인
- [x]  낡은 version으로 이동 시 409 응답 확인
- [x]  자기 자신 또는 하위 블록을 부모로 지정하면 400 응답 확인
- [x]  다른 문서의 블록을 부모 또는 anchor로 사용하면 400 응답 확인

---

## ✅ PR 체크리스트

<!--
PR 올리기 전에 스스로 한 번 더 점검하는 용도입니다.
팀 컨벤션에 맞게 자유롭게 수정해서 사용하세요.
-->

- [x] 불필요한 디버그 로그 / 주석 제거
- [x] breaking change 여부 확인 및 문서화
- [x] 신규/변경된 기능에 대한 테스트 코드 추가 또는 기존 테스트 통과
- [x] 로컬에서 주요 시나리오 수동 테스트 완료
- [x] 관련 문서(노션, README, API 문서 등) 업데이트