### PR TITLE
refactor: Controller 책임 재정리 및 Block API 변경

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -570,7 +570,7 @@ Block {
 - conflict 후 pending 복구는 실패한 batch payload 복원이 아니라, 현재 로컬 문서 상태 기준 재조립을 원칙으로 한다.
 - 같은 실패 batch 안의 non-conflict 변경도 서버에는 미반영이므로, 로컬 상태가 유지되고 있으면 다시 pending에 포함될 수 있다.
 - 같은 블록 안의 비중첩 수정도 v1에서는 block 단위 충돌로 처리할 수 있다.
-- `POST /v1/documents/{documentId}/blocks`, `PATCH /v1/blocks/{blockId}`, `DELETE /v1/blocks/{blockId}`는 에디터 표준 저장 경로가 아니라 운영/관리/비에디터 보조 경로로 둘 수 있다.
+- `POST /v1/admin/documents/{documentId}/blocks`, `PATCH /v1/admin/blocks/{blockId}`, `POST /v1/admin/blocks/{blockId}/move`, `DELETE /v1/admin/blocks/{blockId}`는 에디터 표준 저장 경로가 아니라 운영/관리/비에디터 보조 경로로 둘 수 있다.
 
 ## 10.2 향후 확장
 다음 기능은 v2 이후 별도 서비스 또는 확장 모듈로 분리 가능하다.
@@ -717,11 +717,14 @@ Block {
 
 ## 12.4 블록 API
 
+- 문서 단위 블록 목록 조회는 문서 API 책임으로 `GET /v1/documents/{documentId}/blocks` 경로를 사용한다.
+- 블록 생성, 수정, 이동, 삭제는 관리자 블록 API 책임으로 `/v1/admin/**` 경로를 사용한다.
+
 ### `GET /v1/documents/{documentId}/blocks`
 문서 내 블록 목록 조회.
 - 조회 결과는 soft delete되지 않은 블록만 포함하며 정렬 순서를 보장해야 한다.
 
-### `POST /v1/documents/{documentId}/blocks`
+### `POST /v1/admin/documents/{documentId}/blocks`
 TEXT 블록 생성.
 - 이 API는 운영/관리/비에디터 경로에서 사용할 수 있다.
 - 에디터 표준 생성/저장 경로는 `transactions`를 사용한다.
@@ -735,7 +738,7 @@ TEXT 블록 생성.
 }
 ```
 
-### `PATCH /v1/blocks/{blockId}`
+### `PATCH /v1/admin/blocks/{blockId}`
 블록 내용 또는 블록 자체 메타데이터 수정.
 - 이 API는 운영/관리/비에디터 보조 경로로 둘 수 있다.
 - 에디터 표준 본문 저장 경로는 `transactions`를 사용한다.
@@ -769,7 +772,22 @@ TEXT 블록 생성.
 }
 ```
 
-### `DELETE /v1/blocks/{blockId}`
+### `POST /v1/admin/blocks/{blockId}/move`
+단일 블록 이동.
+- 이 API는 운영/관리/비에디터 보조 경로로 둘 수 있다.
+- 에디터 표준 이동 경로는 `transactions`를 사용한다.
+
+위치 변경 예시:
+```json
+{
+  "parentId": "new-parent-block-id",
+  "afterBlockId": "blk-a",
+  "beforeBlockId": "blk-b",
+  "version": 3
+}
+```
+
+### `DELETE /v1/admin/blocks/{blockId}`
 블록 soft delete.
 - 지정 루트 블록과 하위 블록 subtree를 함께 soft delete 한다.
 - 이 API는 명시적 단일 삭제 액션 또는 운영/관리/비에디터 경로에서 사용할 수 있다.

--- a/documents-api/src/main/java/com/documents/api/block/AdminBlockController.java
+++ b/documents-api/src/main/java/com/documents/api/block/AdminBlockController.java
@@ -12,12 +12,10 @@ import com.documents.service.BlockService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,28 +25,17 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Block", description = "블록 API")
+@Tag(name = "AdminBlock", description = "관리자 블록 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1")
-public class BlockController {
+@RequestMapping("/v1/admin")
+public class AdminBlockController {
 
     private static final String USER_ID_HEADER = "X-User-Id";
 
     private final BlockService blockService;
     private final BlockApiMapper blockApiMapper;
     private final BlockJsonCodec blockJsonCodec;
-
-    @Operation(summary = "문서 블록 목록 조회")
-    @GetMapping("/documents/{documentId}/blocks")
-    public ResponseEntity<GlobalResponse<List<BlockResponse>>> getBlocks(
-            @PathVariable("documentId") UUID documentId
-    ) {
-        List<BlockResponse> response = blockService.getAllByDocumentId(documentId).stream()
-                .map(blockApiMapper::toResponse)
-                .toList();
-        return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, response));
-    }
 
     @Operation(summary = "텍스트 블록 생성")
     @PostMapping("/documents/{documentId}/blocks")

--- a/documents-api/src/main/java/com/documents/api/document/DocumentController.java
+++ b/documents-api/src/main/java/com/documents/api/document/DocumentController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.documents.api.block.BlockApiMapper;
+import com.documents.api.block.dto.BlockResponse;
 import com.documents.api.code.SuccessCode;
 import com.documents.api.document.dto.CreateDocumentRequest;
 import com.documents.api.document.dto.DocumentResponse;
@@ -23,6 +25,7 @@ import com.documents.api.document.dto.DocumentTransactionResponse;
 import com.documents.api.document.dto.UpdateDocumentRequest;
 import com.documents.api.dto.GlobalResponse;
 import com.documents.domain.Document;
+import com.documents.service.BlockService;
 import com.documents.service.DocumentService;
 import com.documents.service.DocumentTransactionService;
 
@@ -40,6 +43,8 @@ public class DocumentController {
 	// TODO: 임시 헤더 값. 인증 서버와 연동 후 수정 필요
 	private static final String USER_ID_HEADER = "X-User-Id";
 
+	private final BlockService blockService;
+	private final BlockApiMapper blockApiMapper;
 	private final DocumentService documentService;
 	private final DocumentApiMapper documentApiMapper;
 	private final DocumentTransactionService documentTransactionService;
@@ -83,6 +88,17 @@ public class DocumentController {
 	) {
 		Document document = documentService.getById(documentId);
 		return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, documentApiMapper.toResponse(document)));
+	}
+
+	@Operation(summary = "문서 블록 목록 조회")
+	@GetMapping("/documents/{documentId}/blocks")
+	public ResponseEntity<GlobalResponse<List<BlockResponse>>> getBlocks(
+		@PathVariable("documentId") UUID documentId
+	) {
+		List<BlockResponse> response = blockService.getAllByDocumentId(documentId).stream()
+			.map(blockApiMapper::toResponse)
+			.toList();
+		return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, response));
 	}
 
 	@Operation(summary = "문서 수정")

--- a/documents-api/src/test/java/com/documents/api/block/AdminBlockControllerWebMvcTest.java
+++ b/documents-api/src/test/java/com/documents/api/block/AdminBlockControllerWebMvcTest.java
@@ -6,7 +6,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -32,14 +31,11 @@ import com.documents.service.BlockService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("Block 컨트롤러 빠른 검증")
-class BlockControllerWebMvcTest {
+@DisplayName("AdminBlock 컨트롤러 빠른 검증")
+class AdminBlockControllerWebMvcTest {
 
     private static final String SIMPLE_CONTENT_SERIALIZED = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"새 블록\",\"marks\":[]}]}";
     private static final String UPDATED_CONTENT_SERIALIZED = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"수정된 블록\",\"marks\":[]}]}";
-    private static final String ROOT_CONTENT_SERIALIZED = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"루트 블록\",\"marks\":[]}]}";
-    private static final String CHILD_CONTENT_SERIALIZED = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"자식 블록\",\"marks\":[]}]}";
-
     @Mock
     private BlockService blockService;
 
@@ -51,7 +47,7 @@ class BlockControllerWebMvcTest {
         validator.afterPropertiesSet();
         BlockJsonCodec blockJsonCodec = new BlockJsonCodec(new ObjectMapper());
 
-        mockMvc = MockMvcBuilders.standaloneSetup(new BlockController(
+        mockMvc = MockMvcBuilders.standaloneSetup(new AdminBlockController(
                         blockService,
                         new BlockApiMapper(blockJsonCodec),
                         blockJsonCodec
@@ -59,32 +55,6 @@ class BlockControllerWebMvcTest {
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .setValidator(validator)
                 .build();
-    }
-
-    @Test
-    @DisplayName("성공_문서 블록 목록 조회 요청에 대해 활성 블록 전체를 반환한다")
-    void getBlocksReturnsAllActiveBlocks() throws Exception {
-        UUID documentId = UUID.randomUUID();
-        UUID rootBlockId = UUID.randomUUID();
-        UUID childBlockId = UUID.randomUUID();
-
-        when(blockService.getAllByDocumentId(documentId)).thenReturn(List.of(
-                block(rootBlockId, documentId, null, "000000000001000000000000", 0, "루트 블록"),
-                block(childBlockId, documentId, rootBlockId, "000000000001I00000000000", 1, "자식 블록")
-        ));
-
-        mockMvc.perform(get("/v1/documents/{documentId}/blocks", documentId))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].id").value(rootBlockId.toString()))
-                .andExpect(jsonPath("$.data[0].content.format").value("rich_text"))
-                .andExpect(jsonPath("$.data[0].content.segments[0].text").value("루트 블록"))
-                .andExpect(jsonPath("$.data[1].parentId").value(rootBlockId.toString()))
-                .andExpect(jsonPath("$.data[1].content.format").value("rich_text"))
-                .andExpect(jsonPath("$.data[1].content.segments[0].text").value("자식 블록"));
     }
 
     @Test
@@ -114,7 +84,7 @@ class BlockControllerWebMvcTest {
                 eq("user-123")
         )).thenReturn(createdBlock);
 
-        mockMvc.perform(post("/v1/documents/{documentId}/blocks", documentId)
+        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", documentId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -169,7 +139,7 @@ class BlockControllerWebMvcTest {
         when(blockService.update(eq(blockId), eq(UPDATED_CONTENT_SERIALIZED), eq(0), eq("user-123")))
                 .thenReturn(updatedBlock);
 
-        mockMvc.perform(patch("/v1/blocks/{blockId}", blockId)
+        mockMvc.perform(patch("/v1/admin/blocks/{blockId}", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -205,7 +175,7 @@ class BlockControllerWebMvcTest {
 		when(blockService.delete(blockId, 3, "user-123"))
 				.thenReturn(block(blockId, UUID.randomUUID(), null, "000000000001000000000000", 0, "삭제 대상"));
 
-		mockMvc.perform(delete("/v1/blocks/{blockId}", blockId)
+		mockMvc.perform(delete("/v1/admin/blocks/{blockId}", blockId)
 						.param("version", "3")
                         .header("X-User-Id", "user-123"))
                 .andExpect(status().isOk())
@@ -221,7 +191,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_type이 없으면 유효성 검사 오류를 반환한다")
     void createBlockRejectsMissingType() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -258,7 +228,7 @@ class BlockControllerWebMvcTest {
                 eq("user-123")
         )).thenThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND));
 
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", documentId)
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", documentId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -284,7 +254,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_인증 헤더가 없으면 블록 생성 API는 인증 오류를 반환한다")
     void createBlockReturnsUnauthorizedWhenHeaderMissing() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .content("""
                                 {
@@ -308,7 +278,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_content가 없으면 유효성 검사 오류를 반환한다")
     void createBlockRejectsMissingContent() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -323,7 +293,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_content format이 다르면 유효성 검사 오류를 반환한다")
     void createBlockRejectsUnsupportedContentFormat() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -348,7 +318,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_mark 타입이 허용 목록이 아니면 유효성 검사 오류를 반환한다")
     void createBlockRejectsUnsupportedMarkType() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -378,7 +348,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_textColor 값이 hex 형식이 아니면 유효성 검사 오류를 반환한다")
     void createBlockRejectsInvalidTextColor() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -408,7 +378,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_같은 segment에 중복 mark 타입이 있으면 유효성 검사 오류를 반환한다")
     void createBlockRejectsDuplicateMarkType() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -436,7 +406,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_textColor 외 mark에 value가 있으면 유효성 검사 오류를 반환한다")
     void createBlockRejectsUnexpectedMarkValue() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -466,7 +436,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_segment에 허용되지 않은 필드가 있으면 유효성 검사 오류를 반환한다")
     void createBlockRejectsUnexpectedSegmentField() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -492,7 +462,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_빈 segment가 중간에 섞여 있으면 유효성 검사 오류를 반환한다")
     void createBlockRejectsEmptySegmentInMultiSegmentContent() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -543,7 +513,7 @@ class BlockControllerWebMvcTest {
                 eq("user-123")
         )).thenReturn(createdBlock);
 
-        mockMvc.perform(post("/v1/documents/{documentId}/blocks", documentId)
+        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", documentId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -568,7 +538,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_content가 없으면 블록 수정 요청은 유효성 검사 오류를 반환한다")
     void updateBlockRejectsMissingContent() throws Exception {
-        var result = mockMvc.perform(patch("/v1/blocks/{blockId}", UUID.randomUUID())
+        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -588,7 +558,7 @@ class BlockControllerWebMvcTest {
         when(blockService.update(eq(blockId), eq(UPDATED_CONTENT_SERIALIZED), eq(0), eq("user-123")))
                 .thenThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND));
 
-        var result = mockMvc.perform(patch("/v1/blocks/{blockId}", blockId)
+        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -613,7 +583,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_인증 헤더가 없으면 블록 수정 API는 인증 오류를 반환한다")
     void updateBlockReturnsUnauthorizedWhenHeaderMissing() throws Exception {
-        var result = mockMvc.perform(patch("/v1/blocks/{blockId}", UUID.randomUUID())
+        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", UUID.randomUUID())
                         .contentType("application/json")
                         .content("""
                                 {
@@ -641,7 +611,7 @@ class BlockControllerWebMvcTest {
         doThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND))
                 .when(blockService).delete(blockId, 3, "user-123");
 
-        var result = mockMvc.perform(delete("/v1/blocks/{blockId}", blockId)
+        var result = mockMvc.perform(delete("/v1/admin/blocks/{blockId}", blockId)
                         .param("version", "3")
                         .header("X-User-Id", "user-123"));
 
@@ -651,7 +621,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_version 없이 블록 삭제를 요청하면 유효성 오류를 반환한다")
     void deleteBlockReturnsBadRequestWhenVersionMissing() throws Exception {
-        var result = mockMvc.perform(delete("/v1/blocks/{blockId}", UUID.randomUUID())
+        var result = mockMvc.perform(delete("/v1/admin/blocks/{blockId}", UUID.randomUUID())
                         .header("X-User-Id", "user-123"));
 
         ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
@@ -660,7 +630,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_인증 헤더가 없으면 블록 삭제 API는 인증 오류를 반환한다")
     void deleteBlockReturnsUnauthorizedWhenHeaderMissing() throws Exception {
-        var result = mockMvc.perform(delete("/v1/blocks/{blockId}", UUID.randomUUID())
+        var result = mockMvc.perform(delete("/v1/admin/blocks/{blockId}", UUID.randomUUID())
                         .param("version", "0"));
 
         ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
@@ -669,7 +639,7 @@ class BlockControllerWebMvcTest {
     @Test
     @DisplayName("실패_version이 없으면 유효성 검사 오류를 반환한다")
     void updateBlockRejectsMissingVersion() throws Exception {
-        var result = mockMvc.perform(patch("/v1/blocks/{blockId}", UUID.randomUUID())
+        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -698,7 +668,7 @@ class BlockControllerWebMvcTest {
         when(blockService.update(eq(blockId), eq(UPDATED_CONTENT_SERIALIZED), eq(0), eq("user-123")))
                 .thenThrow(new BusinessException(BusinessErrorCode.CONFLICT));
 
-        var result = mockMvc.perform(patch("/v1/blocks/{blockId}", blockId)
+        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -725,7 +695,7 @@ class BlockControllerWebMvcTest {
     void moveBlockReturnsSuccessEnvelopeForRootMove() throws Exception {
         UUID blockId = UUID.randomUUID();
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -753,7 +723,7 @@ class BlockControllerWebMvcTest {
         UUID parentId = UUID.randomUUID();
         UUID afterBlockId = UUID.randomUUID();
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -777,7 +747,7 @@ class BlockControllerWebMvcTest {
     void moveBlockReturnsUnauthorizedWhenHeaderMissing() throws Exception {
         UUID blockId = UUID.randomUUID();
 
-        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
                         .contentType("application/json")
                         .content("""
                                 {
@@ -797,7 +767,7 @@ class BlockControllerWebMvcTest {
     void moveBlockReturnsValidationErrorWhenVersionMissing() throws Exception {
         UUID blockId = UUID.randomUUID();
 
-        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -819,7 +789,7 @@ class BlockControllerWebMvcTest {
         doThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND))
                 .when(blockService).move(blockId, null, null, null, 0, "user-123");
 
-        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -841,7 +811,7 @@ class BlockControllerWebMvcTest {
         doThrow(new BusinessException(BusinessErrorCode.CONFLICT))
                 .when(blockService).move(blockId, null, null, null, 0, "user-123");
 
-        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -863,7 +833,7 @@ class BlockControllerWebMvcTest {
         doThrow(new BusinessException(BusinessErrorCode.INVALID_REQUEST))
                 .when(blockService).move(blockId, blockId, null, null, 0, "user-123");
 
-        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", blockId)
+        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""

--- a/documents-api/src/test/java/com/documents/api/document/DocumentControllerWebMvcTest.java
+++ b/documents-api/src/test/java/com/documents/api/document/DocumentControllerWebMvcTest.java
@@ -19,14 +19,18 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
+import com.documents.api.block.BlockApiMapper;
 import com.documents.api.block.support.BlockJsonCodec;
 import com.documents.api.document.support.DocumentJsonCodec;
 import com.documents.api.exception.GlobalExceptionHandler;
 import com.documents.api.support.ApiResponseAssertions;
+import com.documents.domain.Block;
+import com.documents.domain.BlockType;
 import com.documents.domain.Document;
 import com.documents.domain.Workspace;
 import com.documents.exception.BusinessErrorCode;
 import com.documents.exception.BusinessException;
+import com.documents.service.BlockService;
 import com.documents.service.DocumentService;
 import com.documents.service.DocumentTransactionService;
 import com.documents.service.transaction.DocumentTransactionAppliedOperationResult;
@@ -49,7 +53,12 @@ class DocumentControllerWebMvcTest {
 	private static final String ICON_DOC_JSON = "{\"type\":\"emoji\",\"value\":\"📄\"}";
 	private static final String COVER_1_JSON = "{\"type\":\"image\",\"value\":\"cover-1\"}";
 	private static final String COVER_2_JSON = "{\"type\":\"image\",\"value\":\"cover-2\"}";
+	private static final String ROOT_BLOCK_CONTENT_JSON = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"루트 블록\",\"marks\":[]}]}";
+	private static final String CHILD_BLOCK_CONTENT_JSON = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"자식 블록\",\"marks\":[]}]}";
 	private static final LocalDateTime FIXTURE_TIME = LocalDateTime.of(2026, 3, 16, 0, 0);
+
+	@Mock
+	private BlockService blockService;
 
 	@Mock
 	private DocumentService documentService;
@@ -103,21 +112,74 @@ class DocumentControllerWebMvcTest {
 			.build();
 	}
 
+	private Block block(
+		UUID id,
+		UUID documentId,
+		UUID parentId,
+		String sortKey,
+		int version,
+		String content
+	) {
+		Block block = Block.builder()
+			.id(id)
+			.document(Document.builder().id(documentId).workspace(workspace(UUID.randomUUID())).title(ROOT_DOCUMENT_TITLE).build())
+			.parent(parentId == null ? null : Block.builder().id(parentId).build())
+			.type(BlockType.TEXT)
+			.sortKey(sortKey)
+			.content(content)
+			.createdBy(ACTOR_ID)
+			.updatedBy(ACTOR_ID)
+			.build();
+		block.setCreatedAt(FIXTURE_TIME);
+		block.setUpdatedAt(FIXTURE_TIME);
+		block.setVersion(version);
+		return block;
+	}
+
 	@BeforeEach
 	void setUp() {
 		LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
 		validator.afterPropertiesSet();
+		BlockJsonCodec blockJsonCodec = new BlockJsonCodec(new ObjectMapper());
 
-			mockMvc = MockMvcBuilders.standaloneSetup(new DocumentController(
-					documentService,
-					new DocumentApiMapper(new DocumentJsonCodec(new ObjectMapper())),
-					documentTransactionService,
-					new DocumentTransactionApiMapper(new BlockJsonCodec(new ObjectMapper()))
-				))
-				.setControllerAdvice(new GlobalExceptionHandler())
-				.setValidator(validator)
-				.build();
-		}
+		mockMvc = MockMvcBuilders.standaloneSetup(new DocumentController(
+				blockService,
+				new BlockApiMapper(blockJsonCodec),
+				documentService,
+				new DocumentApiMapper(new DocumentJsonCodec(new ObjectMapper())),
+				documentTransactionService,
+				new DocumentTransactionApiMapper(blockJsonCodec)
+			))
+			.setControllerAdvice(new GlobalExceptionHandler())
+			.setValidator(validator)
+			.build();
+	}
+
+	@Test
+	@DisplayName("성공_문서 블록 목록 조회 요청에 대해 활성 블록 전체를 반환한다")
+	void getBlocksReturnsAllActiveBlocks() throws Exception {
+		UUID documentId = UUID.randomUUID();
+		UUID rootBlockId = UUID.randomUUID();
+		UUID childBlockId = UUID.randomUUID();
+
+		when(blockService.getAllByDocumentId(documentId)).thenReturn(List.of(
+			block(rootBlockId, documentId, null, "000000000001000000000000", 0, ROOT_BLOCK_CONTENT_JSON),
+			block(childBlockId, documentId, rootBlockId, "000000000001I00000000000", 1, CHILD_BLOCK_CONTENT_JSON)
+		));
+
+		mockMvc.perform(get("/v1/documents/{documentId}/blocks", documentId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.httpStatus").value("OK"))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.code").value(200))
+			.andExpect(jsonPath("$.data.length()").value(2))
+			.andExpect(jsonPath("$.data[0].id").value(rootBlockId.toString()))
+			.andExpect(jsonPath("$.data[0].content.format").value("rich_text"))
+			.andExpect(jsonPath("$.data[0].content.segments[0].text").value("루트 블록"))
+			.andExpect(jsonPath("$.data[1].parentId").value(rootBlockId.toString()))
+			.andExpect(jsonPath("$.data[1].content.format").value("rich_text"))
+			.andExpect(jsonPath("$.data[1].content.segments[0].text").value("자식 블록"));
+	}
 
 	@Test
 	@DisplayName("성공_create와 replace_content transaction 요청에 대해 매핑 응답을 반환한다")

--- a/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
@@ -120,7 +120,7 @@ class BlockApiIntegrationTest {
                 .sortKey("00000000000000000001")
                 .build());
 
-                mockMvc.perform(post("/v1/documents/{documentId}/blocks", document.getId())
+                mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", document.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -187,7 +187,7 @@ class BlockApiIntegrationTest {
                 .updatedBy("user-123")
                 .build());
 
-        mockMvc.perform(patch("/v1/blocks/{blockId}", block.getId())
+        mockMvc.perform(patch("/v1/admin/blocks/{blockId}", block.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-456")
                         .content("""
@@ -247,7 +247,7 @@ class BlockApiIntegrationTest {
         block.setContent(toContent("다른 사용자 수정"));
         blockRepository.save(block);
 
-        mockMvc.perform(patch("/v1/blocks/{blockId}", block.getId())
+        mockMvc.perform(patch("/v1/admin/blocks/{blockId}", block.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-456")
                         .content("""
@@ -289,7 +289,7 @@ class BlockApiIntegrationTest {
         Block grandChildBlock = saveBlock(document, childBlock, "삭제 대상 손자", "000000000001Q00000000000");
         Block otherRootBlock = saveBlock(document, null, "보존 대상", "000000000002000000000000");
 
-        mockMvc.perform(delete("/v1/blocks/{blockId}", rootBlock.getId())
+        mockMvc.perform(delete("/v1/admin/blocks/{blockId}", rootBlock.getId())
                         .param("version", "0")
                         .header("X-User-Id", "user-123"))
                 .andExpect(status().isOk())
@@ -311,7 +311,7 @@ class BlockApiIntegrationTest {
     @Test
     @DisplayName("실패_존재하지 않는 블록을 삭제하면 블록 없음 응답을 반환한다")
     void deleteBlockReturnsNotFoundWhenBlockMissing() throws Exception {
-        var result = mockMvc.perform(delete("/v1/blocks/{blockId}", UUID.randomUUID())
+        var result = mockMvc.perform(delete("/v1/admin/blocks/{blockId}", UUID.randomUUID())
                         .param("version", "0")
                         .header("X-User-Id", "user-123"));
 
@@ -336,7 +336,7 @@ class BlockApiIntegrationTest {
                 .build());
         Block rootBlock = saveBlock(document, null, "삭제 대상 루트", "000000000001000000000000");
 
-        mockMvc.perform(delete("/v1/blocks/{blockId}", rootBlock.getId())
+        mockMvc.perform(delete("/v1/admin/blocks/{blockId}", rootBlock.getId())
                         .param("version", "-1")
                         .header("X-User-Id", "user-123"))
                 .andExpect(status().isConflict())
@@ -377,7 +377,7 @@ class BlockApiIntegrationTest {
                 .updatedBy("user-123")
                 .build());
 
-        mockMvc.perform(post("/v1/documents/{documentId}/blocks", document.getId())
+        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", document.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -406,7 +406,7 @@ class BlockApiIntegrationTest {
     @Test
     @DisplayName("실패_존재하지 않는 문서로 블록을 생성하면 문서 없음 응답을 반환한다")
     void createBlockReturnsNotFoundWhenDocumentMissing() throws Exception {
-        var result = mockMvc.perform(post("/v1/documents/{documentId}/blocks", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -448,7 +448,7 @@ class BlockApiIntegrationTest {
         Block moved = saveBlock(document, null, "이동 대상", "000000000002000000000000");
         Block third = saveBlock(document, null, "셋째 블록", "000000000003000000000000");
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", moved.getId())
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-456")
                         .content("""
@@ -490,7 +490,7 @@ class BlockApiIntegrationTest {
         saveBlock(document, parent, "기존 자식", "000000000001000000000000");
         Block moved = saveBlock(document, null, "이동 대상", "000000000002000000000000");
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", moved.getId())
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-456")
                         .content("""
@@ -531,7 +531,7 @@ class BlockApiIntegrationTest {
         Block second = saveBlock(document, parent, "둘째 자식", "000000000002000000000000");
         Block moved = saveBlock(document, parent, "이동 대상", "000000000003000000000000");
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", moved.getId())
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-456")
                         .content("""
@@ -558,7 +558,7 @@ class BlockApiIntegrationTest {
     @Test
     @DisplayName("실패_존재하지 않는 블록 이동은 블록 없음 응답을 반환한다")
     void moveBlockReturnsNotFoundWhenBlockMissing() throws Exception {
-        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", UUID.randomUUID())
+        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", UUID.randomUUID())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -600,7 +600,7 @@ class BlockApiIntegrationTest {
                 .deletedAt(java.time.LocalDateTime.of(2026, 3, 20, 0, 0))
                 .build());
 
-        var result = mockMvc.perform(post("/v1/blocks/{blockId}/move", deleted.getId())
+        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", deleted.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -635,7 +635,7 @@ class BlockApiIntegrationTest {
         block.setContent(toContent("다른 사용자 수정"));
         blockRepository.save(block);
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", block.getId())
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", block.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-456")
                         .content("""
@@ -667,7 +667,7 @@ class BlockApiIntegrationTest {
                 .build());
         Block block = saveBlock(document, null, "이동 대상", "000000000001000000000000");
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", block.getId())
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", block.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -700,7 +700,7 @@ class BlockApiIntegrationTest {
         Block root = saveBlock(document, null, "루트", "000000000001000000000000");
         Block child = saveBlock(document, root, "자식", "000000000001000000000000");
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", root.getId())
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", root.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -742,7 +742,7 @@ class BlockApiIntegrationTest {
         Block depth10 = saveBlock(document, depth9, "10", "000000000001000000000000");
         Block moved = saveBlock(document, null, "이동 대상", "000000000002000000000000");
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", moved.getId())
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -782,7 +782,7 @@ class BlockApiIntegrationTest {
         Block otherParent = saveBlock(otherDocument, null, "다른 부모", "000000000001000000000000");
         Block otherAnchor = saveBlock(otherDocument, null, "다른 anchor", "000000000002000000000000");
 
-        mockMvc.perform(post("/v1/blocks/{blockId}/move", moved.getId())
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -813,7 +813,7 @@ class BlockApiIntegrationTest {
                 .sortKey("00000000000000000001")
                 .build());
 
-        mockMvc.perform(post("/v1/documents/{documentId}/blocks", document.getId())
+        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", document.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
@@ -856,7 +856,7 @@ class BlockApiIntegrationTest {
                 .sortKey("00000000000000000001")
                 .build());
 
-        mockMvc.perform(post("/v1/documents/{documentId}/blocks", document.getId())
+        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", document.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""

--- a/prompts/2026-03-24-controller-refactor.md
+++ b/prompts/2026-03-24-controller-refactor.md
@@ -1,0 +1,7 @@
+# 2026-03-24 컨트롤러 리팩토링 재적용
+
+- 작업 목표: 블록 조회 책임을 문서 컨트롤러로 이동하고 블록 관리 API를 admin 경로로 재정리
+- Step 1: `GET /v1/documents/{documentId}/blocks`를 `DocumentController`에 추가
+- Step 2: `BlockController`를 `AdminBlockController`로 변경하고 생성/수정/이동/삭제를 `/v1/admin/**`로 재매핑
+- Step 3: WebMvc 테스트를 현재 컨트롤러 책임과 URL 기준으로 정리
+- Step 4: `docs/REQUIREMENTS.md`에 admin 블록 API 경로와 책임 분리를 반영


### PR DESCRIPTION
<!--
제목 작성 요령
[${CONVENTION}] ${구현 내용 요약}

CONVENTION 예시
- [FEAT]  : 새로운 기능 추가
- [FIX]   : 버그 수정
- [REFACTOR] : 코드 리팩터링 (기능 변화 X)
- [CHORE] : 빌드/설정/환경 변경
- [DOCS]  : 문서 수정
-->

## 📝 Part (해당되는 것만 체크)

- [x] BE
- [ ] FE
- [ ] Infra
- [x] Docs
- [x] Test

---

## #️⃣ 연관된 이슈

<!--
이슈와 PR를 자동으로 연결하기 위한 영역입니다.
예시:
- closes #17
- fixes #24
여러 개일 경우 쉼표로 구분해서 적어주세요.
-->

closes #36 

---

## 🔎 작업 내용

<!--
무슨 일을 했는지 "한 눈에" 이해할 수 있게 적어주세요.
가능하면 bullet 형식으로 요약해 주세요.
-->

### 1. 주요 변경 사항 요약

- `GET /v1/documents/{documentId}/blocks`를 `BlockController`에서 `DocumentController`로 이동
- `BlockController`를 `AdminBlockController`로 변경
- 블록 생성/수정/이동/삭제 API를 `/v1/admin/**` 경로로 재매핑
- 변경된 컨트롤러 책임과 URL 구조에 맞게 WebMvc 테스트를 정리
- `docs/REQUIREMENTS.md`에 admin 블록 API 경로와 책임 분리 내용을 반영
- `prompts/2026-03-24-controller-refactor.md`에 작업 로그를 추가

### 2. 상세 내용 (선택)

- 문서 블록 목록 조회는 문서 리소스 조회 성격이므로 `DocumentController`로 이동했습니다.
- 블록 생성/수정/이동/삭제는 관리자 성격의 API로 보고 `AdminBlockController`에서 `/v1/admin/**` 경로로 처리하도록 정리했습니다.
- 현재 `WorkspaceController`는 이번 변경 범위에 포함하지 않았습니다.
- 요구사항 문서에는 조회와 관리자 블록 API의 책임 분리 및 변경된 경로를 함께 반영했습니다.

### 3. 프롬프트 경로

- [/prompts/2026-03-24-controller-refactor.md](https://github.com/jho951/Block-server/blob/main/prompts/2026-03-24-controller-refactor.md)

### 4. 참조 문서 경로 (ADR, discussions, roadMap ...)
- [/docs/REQUIREMENTS.md](https://github.com/jho951/Block-server/blob/main/docs/REQUIREMENTS.md)

---

## 💬 집중 리뷰 요청

<!--
리뷰어가 어디를 중점적으로 봐야 하는지 알려주세요.
복잡한 로직, 트레이드오프, 고민했던 포인트를 적어주면 리뷰 품질이 올라갑니다.
-->

- `GET /v1/documents/{documentId}/blocks`를 `DocumentController`로 이동한 현재 책임 분리가 팀 의도와 맞는지 확인 부탁드립니다.
- 블록 생성/수정/이동/삭제를 `/v1/admin/**`로 분리한 URL 정책이 적절한지 확인 부탁드립니다.

---

## 🧪 테스트 방법

<!--
리뷰어/테스터가 동일하게 재현할 수 있도록, 테스트 방법을 구체적으로 적어주세요.
로컬/스테이징 환경 기준, 실행 커맨드가 있으면 함께 작성해 주세요.
-->

### 1. 로컬 실행 방법

- `./gradlew --no-daemon :documents-api:test --tests com.documents.api.document.DocumentControllerWebMvcTest --tests com.documents.api.block.AdminBlockControllerWebMvcTest`

### 2. 테스트 시나리오

- [x] `GET /v1/documents/{documentId}/blocks`가 `DocumentController` 기준으로 정상 응답하는지 확인
- [x] `POST /v1/admin/documents/{documentId}/blocks`가 정상 동작하는지 확인
- [x] `PATCH /v1/admin/blocks/{blockId}`가 정상 동작하는지 확인
- [x] `POST /v1/admin/blocks/{blockId}/move`가 정상 동작하는지 확인
- [x] `DELETE /v1/admin/blocks/{blockId}`가 정상 동작하는지 확인

---

## ✅ PR 체크리스트

<!--
PR 올리기 전에 스스로 한 번 더 점검하는 용도입니다.
팀 컨벤션에 맞게 자유롭게 수정해서 사용하세요.
-->

- [ ] 불필요한 디버그 로그 / 주석 제거
- [ ] breaking change 여부 확인 및 문서화
- [ ] 신규/변경된 기능에 대한 테스트 코드 추가 또는 기존 테스트 통과
- [ ] 로컬에서 주요 시나리오 수동 테스트 완료
- [ ] 관련 문서(노션, README, API 문서 등) 업데이트