### PR TITLE
refactor: Admin 전용 블록 CRUD API의 내부 처리 및 요청/응답 계약을 기존 에디터 저장 로직에 맞추도록 리팩토링

### DIFF
--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -608,6 +608,8 @@ Block {
 - 같은 실패 batch 안의 non-conflict 변경도 서버에는 미반영이므로, 로컬 상태가 유지되고 있으면 다시 pending에 포함될 수 있다.
 - 같은 블록 안의 비중첩 수정도 v1에서는 block 단위 충돌로 처리할 수 있다.
 - `POST /v1/admin/documents/{documentId}/blocks`, `PATCH /v1/admin/blocks/{blockId}`, `POST /v1/admin/blocks/{blockId}/move`, `DELETE /v1/admin/blocks/{blockId}`는 에디터 표준 저장 경로가 아니라 운영/관리/비에디터 보조 경로로 둘 수 있다.
+- 위 4개 admin block API는 path와 HTTP method는 유지하되, request/response 계약과 실제 실행 로직은 `POST /v1/documents/{documentId}/transactions`와 동일한 transaction 모델을 사용해야 한다.
+- 각 admin block API는 자기 역할에 맞는 단일 operation 하나만 허용해야 한다.
 
 ## 10.2 향후 확장
 다음 기능은 v2 이후 별도 서비스 또는 확장 모듈로 분리 가능하다.
@@ -773,13 +775,25 @@ Block {
 TEXT 블록 생성.
 - 이 API는 운영/관리/비에디터 경로에서 사용할 수 있다.
 - 에디터 표준 생성/저장 경로는 `transactions`를 사용한다.
+- 요청 body는 `POST /v1/documents/{documentId}/transactions`와 같은 transaction request 구조를 사용해야 한다.
+- `operations`는 길이 1이어야 하며, 유일한 operation의 `type`은 `BLOCK_CREATE`여야 한다.
+- 응답 body는 `DocumentTransactionResponse`와 동일해야 한다.
 
 요청 예시:
 ```json
 {
-  "parentId": null,
-  "afterBlockId": null,
-  "beforeBlockId": null
+  "clientId": "admin-api",
+  "batchId": "batch-create",
+  "operations": [
+    {
+      "opId": "op-1",
+      "type": "BLOCK_CREATE",
+      "blockRef": "tmp:block:1",
+      "parentRef": null,
+      "afterRef": null,
+      "beforeRef": null
+    }
+  ]
 }
 ```
 
@@ -787,33 +801,47 @@ TEXT 블록 생성.
 블록 내용 또는 블록 자체 메타데이터 수정.
 - 이 API는 운영/관리/비에디터 보조 경로로 둘 수 있다.
 - 에디터 표준 본문 저장 경로는 `transactions`를 사용한다.
+- 요청 body는 `POST /v1/documents/{documentId}/transactions`와 같은 transaction request 구조를 사용해야 한다.
+- `operations`는 길이 1이어야 하며, 유일한 operation의 `type`은 `BLOCK_REPLACE_CONTENT`여야 한다.
+- path의 `blockId`와 operation의 `blockRef`는 동일해야 한다.
+- 서버는 `blockId`로 소속 `documentId`를 해석한 뒤 transaction과 같은 서비스 경로를 호출해야 한다.
+- 응답 body는 `DocumentTransactionResponse`와 동일해야 한다.
 
 내용 수정 예시:
 ```json
 {
-  "content": {
-    "format": "rich_text",
-    "schemaVersion": 1,
-    "segments": [
-      {
-        "text": "수정된 ",
-        "marks": []
-      },
-      {
-        "text": "내용",
-        "marks": [
+  "clientId": "admin-api",
+  "batchId": "batch-update",
+  "operations": [
+    {
+      "opId": "op-1",
+      "type": "BLOCK_REPLACE_CONTENT",
+      "blockRef": "real-block-id",
+      "version": 3,
+      "content": {
+        "format": "rich_text",
+        "schemaVersion": 1,
+        "segments": [
           {
-            "type": "bold"
+            "text": "수정된 ",
+            "marks": []
           },
           {
-            "type": "textColor",
-            "value": "#000000"
+            "text": "내용",
+            "marks": [
+              {
+                "type": "bold"
+              },
+              {
+                "type": "textColor",
+                "value": "#000000"
+              }
+            ]
           }
         ]
       }
-    ]
-  },
-  "version": 3
+    }
+  ]
 }
 ```
 
@@ -821,14 +849,28 @@ TEXT 블록 생성.
 단일 블록 이동.
 - 이 API는 운영/관리/비에디터 보조 경로로 둘 수 있다.
 - 에디터 표준 이동 경로는 `transactions`를 사용한다.
+- 요청 body는 `POST /v1/documents/{documentId}/transactions`와 같은 transaction request 구조를 사용해야 한다.
+- `operations`는 길이 1이어야 하며, 유일한 operation의 `type`은 `BLOCK_MOVE`여야 한다.
+- path의 `blockId`와 operation의 `blockRef`는 동일해야 한다.
+- 서버는 `blockId`로 소속 `documentId`를 해석한 뒤 transaction과 같은 서비스 경로를 호출해야 한다.
+- 응답 body는 `DocumentTransactionResponse`와 동일해야 한다.
 
 위치 변경 예시:
 ```json
 {
-  "parentId": "new-parent-block-id",
-  "afterBlockId": "blk-a",
-  "beforeBlockId": "blk-b",
-  "version": 3
+  "clientId": "admin-api",
+  "batchId": "batch-move",
+  "operations": [
+    {
+      "opId": "op-1",
+      "type": "BLOCK_MOVE",
+      "blockRef": "real-block-id",
+      "version": 3,
+      "parentRef": "new-parent-block-id",
+      "afterRef": "blk-a",
+      "beforeRef": "blk-b"
+    }
+  ]
 }
 ```
 
@@ -837,6 +879,11 @@ TEXT 블록 생성.
 - 지정 루트 블록과 하위 블록 subtree를 함께 soft delete 한다.
 - 이 API는 명시적 단일 삭제 액션 또는 운영/관리/비에디터 경로에서 사용할 수 있다.
 - 에디터 표준 삭제 경로는 `transactions`를 사용한다.
+- 요청 body는 `POST /v1/documents/{documentId}/transactions`와 같은 transaction request 구조를 사용해야 한다.
+- `operations`는 길이 1이어야 하며, 유일한 operation의 `type`은 `BLOCK_DELETE`여야 한다.
+- path의 `blockId`와 operation의 `blockRef`는 동일해야 한다.
+- 서버는 `blockId`로 소속 `documentId`를 해석한 뒤 transaction과 같은 서비스 경로를 호출해야 한다.
+- 응답 body는 `DocumentTransactionResponse`와 동일해야 한다.
 
 ### `POST /v1/documents/{documentId}/transactions`
 에디터 생성/저장 batch 반영.

--- a/documents-api/src/main/java/com/documents/api/block/AdminBlockController.java
+++ b/documents-api/src/main/java/com/documents/api/block/AdminBlockController.java
@@ -1,19 +1,7 @@
 package com.documents.api.block;
 
-import com.documents.api.block.dto.BlockResponse;
-import com.documents.api.block.dto.CreateBlockRequest;
-import com.documents.api.block.dto.MoveBlockRequest;
-import com.documents.api.block.dto.UpdateBlockRequest;
-import com.documents.api.block.support.BlockJsonCodec;
-import com.documents.api.code.SuccessCode;
-import com.documents.api.dto.GlobalResponse;
-import com.documents.domain.Block;
-import com.documents.service.BlockService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -22,8 +10,20 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import com.documents.api.code.SuccessCode;
+import com.documents.api.document.DocumentTransactionApiMapper;
+import com.documents.api.document.dto.DocumentTransactionRequest;
+import com.documents.api.document.dto.DocumentTransactionResponse;
+import com.documents.api.dto.GlobalResponse;
+import com.documents.service.AdminBlockTransactionService;
+import com.documents.service.transaction.DocumentTransactionCommand;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Tag(name = "AdminBlock", description = "관리자 블록 API")
 @RestController
@@ -33,73 +33,74 @@ public class AdminBlockController {
 
     private static final String USER_ID_HEADER = "X-User-Id";
 
-    private final BlockService blockService;
-    private final BlockApiMapper blockApiMapper;
-    private final BlockJsonCodec blockJsonCodec;
+    private final AdminBlockTransactionService adminBlockTransactionService;
+    private final DocumentTransactionApiMapper documentTransactionApiMapper;
 
     @Operation(summary = "텍스트 블록 생성")
     @PostMapping("/documents/{documentId}/blocks")
-    public ResponseEntity<GlobalResponse<BlockResponse>> createBlock(
+    public ResponseEntity<GlobalResponse<DocumentTransactionResponse>> createBlock(
             @PathVariable("documentId") UUID documentId,
-            @Valid @RequestBody CreateBlockRequest request,
+            @Valid @RequestBody DocumentTransactionRequest request,
             @RequestHeader(USER_ID_HEADER) String userId
     ) {
-        Block createdBlock = blockService.create(
-                documentId,
-                request.getParentId(),
-                request.getType(),
-                blockJsonCodec.write(request.getContent()),
-                request.getAfterBlockId(),
-                request.getBeforeBlockId(),
-                userId
-        );
+        DocumentTransactionCommand command = documentTransactionApiMapper.toCommand(request);
 
-        return ResponseEntity.status(SuccessCode.CREATED.getHttpStatus())
-                .body(GlobalResponse.ok(SuccessCode.CREATED, blockApiMapper.toResponse(createdBlock)));
+        return ResponseEntity.ok(GlobalResponse.ok(
+                SuccessCode.SUCCESS,
+                documentTransactionApiMapper.toResponse(
+                        adminBlockTransactionService.applyCreate(documentId, command.batchId(), command.operations().get(0), userId)
+                )
+        ));
     }
 
     @Operation(summary = "블록 수정")
     @PatchMapping("/blocks/{blockId}")
-    public ResponseEntity<GlobalResponse<BlockResponse>> updateBlock(
+    public ResponseEntity<GlobalResponse<DocumentTransactionResponse>> updateBlock(
             @PathVariable("blockId") UUID blockId,
-            @Valid @RequestBody UpdateBlockRequest request,
+            @Valid @RequestBody DocumentTransactionRequest request,
             @RequestHeader(USER_ID_HEADER) String userId
     ) {
-        Block updatedBlock = blockService.update(
-                blockId,
-                blockJsonCodec.write(request.getContent()),
-                request.getVersion(),
-                userId
-        );
-        return ResponseEntity.ok(GlobalResponse.ok(SuccessCode.SUCCESS, blockApiMapper.toResponse(updatedBlock)));
+        DocumentTransactionCommand command = documentTransactionApiMapper.toCommand(request);
+
+        return ResponseEntity.ok(GlobalResponse.ok(
+                SuccessCode.SUCCESS,
+                documentTransactionApiMapper.toResponse(
+                        adminBlockTransactionService.applyReplaceContent(blockId, command.batchId(), command.operations().get(0), userId)
+                )
+        ));
     }
 
     @Operation(summary = "블록 삭제")
     @DeleteMapping("/blocks/{blockId}")
-    public ResponseEntity<GlobalResponse<Void>> deleteBlock(
+    public ResponseEntity<GlobalResponse<DocumentTransactionResponse>> deleteBlock(
             @PathVariable("blockId") UUID blockId,
-            @RequestParam("version") Integer version,
+            @Valid @RequestBody DocumentTransactionRequest request,
             @RequestHeader(USER_ID_HEADER) String userId
     ) {
-        blockService.delete(blockId, version, userId);
-        return ResponseEntity.ok(GlobalResponse.ok());
+        DocumentTransactionCommand command = documentTransactionApiMapper.toCommand(request);
+
+        return ResponseEntity.ok(GlobalResponse.ok(
+                SuccessCode.SUCCESS,
+                documentTransactionApiMapper.toResponse(
+                        adminBlockTransactionService.applyDelete(blockId, command.batchId(), command.operations().get(0), userId)
+                )
+        ));
     }
 
     @Operation(summary = "블록 이동")
     @PostMapping("/blocks/{blockId}/move")
-    public ResponseEntity<GlobalResponse<Void>> moveBlock(
+    public ResponseEntity<GlobalResponse<DocumentTransactionResponse>> moveBlock(
             @PathVariable("blockId") UUID blockId,
-            @Valid @RequestBody MoveBlockRequest request,
+            @Valid @RequestBody DocumentTransactionRequest request,
             @RequestHeader(USER_ID_HEADER) String userId
     ) {
-        blockService.move(
-                blockId,
-                request.getParentId(),
-                request.getAfterBlockId(),
-                request.getBeforeBlockId(),
-                request.getVersion(),
-                userId
-        );
-        return ResponseEntity.ok(GlobalResponse.ok());
+        DocumentTransactionCommand command = documentTransactionApiMapper.toCommand(request);
+
+        return ResponseEntity.ok(GlobalResponse.ok(
+                SuccessCode.SUCCESS,
+                documentTransactionApiMapper.toResponse(
+                        adminBlockTransactionService.applyMove(blockId, command.batchId(), command.operations().get(0), userId)
+                )
+        ));
     }
 }

--- a/documents-api/src/test/java/com/documents/api/block/AdminBlockControllerWebMvcTest.java
+++ b/documents-api/src/test/java/com/documents/api/block/AdminBlockControllerWebMvcTest.java
@@ -1,13 +1,29 @@
 package com.documents.api.block;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.documents.api.block.support.BlockJsonCodec;
+import com.documents.api.document.DocumentTransactionApiMapper;
+import com.documents.api.exception.GlobalExceptionHandler;
+import com.documents.api.support.ApiResponseAssertions;
+import com.documents.exception.BusinessErrorCode;
+import com.documents.exception.BusinessException;
+import com.documents.service.AdminBlockTransactionService;
+import com.documents.service.transaction.DocumentTransactionAppliedOperationResult;
+import com.documents.service.transaction.DocumentTransactionOperationStatus;
+import com.documents.service.transaction.DocumentTransactionResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,26 +34,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
-import com.documents.api.block.support.BlockJsonCodec;
-import com.documents.api.exception.GlobalExceptionHandler;
-import com.documents.api.support.ApiResponseAssertions;
-import com.documents.domain.Block;
-import com.documents.domain.BlockType;
-import com.documents.domain.Document;
-import com.documents.domain.Workspace;
-import com.documents.exception.BusinessErrorCode;
-import com.documents.exception.BusinessException;
-import com.documents.service.BlockService;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 @ExtendWith(MockitoExtension.class)
 @DisplayName("AdminBlock 컨트롤러 빠른 검증")
 class AdminBlockControllerWebMvcTest {
 
-    private static final String SIMPLE_CONTENT_SERIALIZED = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"새 블록\",\"marks\":[]}]}";
-    private static final String UPDATED_CONTENT_SERIALIZED = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"수정된 블록\",\"marks\":[]}]}";
     @Mock
-    private BlockService blockService;
+    private AdminBlockTransactionService adminBlockTransactionService;
 
     private MockMvc mockMvc;
 
@@ -45,12 +47,11 @@ class AdminBlockControllerWebMvcTest {
     void setUp() {
         LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
         validator.afterPropertiesSet();
-        BlockJsonCodec blockJsonCodec = new BlockJsonCodec(new ObjectMapper());
 
+        BlockJsonCodec blockJsonCodec = new BlockJsonCodec(new ObjectMapper());
         mockMvc = MockMvcBuilders.standaloneSetup(new AdminBlockController(
-                        blockService,
-                        new BlockApiMapper(blockJsonCodec),
-                        blockJsonCodec
+                        adminBlockTransactionService,
+                        new DocumentTransactionApiMapper(blockJsonCodec)
                 ))
                 .setControllerAdvice(new GlobalExceptionHandler())
                 .setValidator(validator)
@@ -58,836 +59,292 @@ class AdminBlockControllerWebMvcTest {
     }
 
     @Test
-    @DisplayName("성공_블록 생성 요청에 대해 gap 기반 sortKey 전략의 생성 응답을 반환한다")
-    void createBlockReturnsCreatedEnvelope() throws Exception {
+    @DisplayName("성공_생성 API는 transaction create 요청을 그대로 위임한다")
+    void createBlockDelegatesSingleCreateTransaction() throws Exception {
         UUID documentId = UUID.randomUUID();
-        UUID parentId = UUID.randomUUID();
-        UUID blockId = UUID.randomUUID();
-
-        Block createdBlock = block(
-                blockId,
-                documentId,
-                parentId,
-                "000000000001000000000000",
-                0,
-                "새 블록"
-        );
-        createdBlock.setContent("{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"새 블록\",\"marks\":[]}]}");
-
-        when(blockService.create(
-                eq(documentId),
-                eq(parentId),
-                eq(BlockType.TEXT),
-                eq(SIMPLE_CONTENT_SERIALIZED),
-                eq(null),
-                eq(null),
-                eq("user-123")
-        )).thenReturn(createdBlock);
+        when(adminBlockTransactionService.applyCreate(eq(documentId), any(), any(), eq("user-123")))
+                .thenReturn(transactionResult(documentId, "tmp:block:1", UUID.randomUUID(), 1, "000000000001000000000000", null));
 
         mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", documentId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
                                 {
-                                  "parentId": "%s",
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-1",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_CREATE",
+                                      "blockRef": "tmp:block:1"
+                                    }
+                                  ]
                                 }
-                                """.formatted(parentId)))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.httpStatus").value("CREATED"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(201))
-                .andExpect(jsonPath("$.data.id").value(blockId.toString()))
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.httpStatus").value("OK"))
+                .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.documentId").value(documentId.toString()))
-                .andExpect(jsonPath("$.data.parentId").value(parentId.toString()))
-                .andExpect(jsonPath("$.data.type").value("TEXT"))
-                .andExpect(jsonPath("$.data.content.format").value("rich_text"))
-                .andExpect(jsonPath("$.data.content.schemaVersion").value(1))
-                .andExpect(jsonPath("$.data.content.segments[0].text").value("새 블록"))
-                .andExpect(jsonPath("$.data.content.segments[0].marks").isArray())
-                .andExpect(jsonPath("$.data.sortKey").value("000000000001000000000000"))
-                .andExpect(jsonPath("$.data.createdBy").value("user-123"))
-                .andExpect(jsonPath("$.data.version").value(0));
+                .andExpect(jsonPath("$.data.batchId").value("batch-1"))
+                .andExpect(jsonPath("$.data.appliedOperations[0].opId").value("op-1"))
+                .andExpect(jsonPath("$.data.appliedOperations[0].status").value("APPLIED"))
+                .andExpect(jsonPath("$.data.appliedOperations[0].tempId").value("tmp:block:1"));
+
+        verify(adminBlockTransactionService).applyCreate(eq(documentId), any(), any(), eq("user-123"));
     }
 
     @Test
-    @DisplayName("성공_블록 수정 요청에 대해 수정 응답을 반환한다")
-    void updateBlockReturnsUpdatedEnvelope() throws Exception {
-        UUID documentId = UUID.randomUUID();
+    @DisplayName("성공_수정 API는 blockId로 문서 ID를 찾아 같은 transaction 경로를 호출한다")
+    void updateBlockDelegatesSingleReplaceContentTransaction() throws Exception {
         UUID blockId = UUID.randomUUID();
-
-        Block updatedBlock = block(
-                        blockId,
-                        documentId,
-                        null,
-                        "000000000001000000000000",
-                        1,
-                        "수정된 블록"
-                );
-        updatedBlock.setContent(UPDATED_CONTENT_SERIALIZED);
-
-        when(blockService.update(eq(blockId), eq(UPDATED_CONTENT_SERIALIZED), eq(0), eq("user-123")))
-                .thenReturn(updatedBlock);
+        UUID documentId = UUID.randomUUID();
+        when(adminBlockTransactionService.applyReplaceContent(eq(blockId), any(), any(), eq("user-456")))
+                .thenReturn(transactionResult(documentId, null, blockId, 1, "000000000001000000000000", null));
 
         mockMvc.perform(patch("/v1/admin/blocks/{blockId}", blockId)
                         .contentType("application/json")
-                        .header("X-User-Id", "user-123")
+                        .header("X-User-Id", "user-456")
                         .content("""
                                 {
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "수정된 블록",
-                                        "marks": []
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-2",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_REPLACE_CONTENT",
+                                      "blockRef": "%s",
+                                      "version": 0,
+                                      "content": {
+                                        "format": "rich_text",
+                                        "schemaVersion": 1,
+                                        "segments": [
+                                          {
+                                            "text": "수정된 블록",
+                                            "marks": []
+                                          }
+                                        ]
                                       }
-                                    ]
-                                  },
-                                  "version": 0
+                                    }
+                                  ]
                                 }
-                                """))
+                                """.formatted(blockId)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value(blockId.toString()))
-                .andExpect(jsonPath("$.data.content.format").value("rich_text"))
-                .andExpect(jsonPath("$.data.content.schemaVersion").value(1))
-                .andExpect(jsonPath("$.data.content.segments[0].text").value("수정된 블록"))
-                .andExpect(jsonPath("$.data.version").value(1));
-    }
+                .andExpect(jsonPath("$.data.documentId").value(documentId.toString()))
+                .andExpect(jsonPath("$.data.appliedOperations[0].blockId").value(blockId.toString()))
+                .andExpect(jsonPath("$.data.appliedOperations[0].version").value(1));
 
-	@Test
-	@DisplayName("성공_정상 삭제 요청에 대해 성공 응답을 반환한다")
-	void deleteBlockReturnsSuccessEnvelope() throws Exception {
-		UUID blockId = UUID.randomUUID();
-		when(blockService.delete(blockId, 3, "user-123"))
-				.thenReturn(block(blockId, UUID.randomUUID(), null, "000000000001000000000000", 0, "삭제 대상"));
-
-		mockMvc.perform(delete("/v1/admin/blocks/{blockId}", blockId)
-						.param("version", "3")
-                        .header("X-User-Id", "user-123"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("요청 응답 성공"))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data").doesNotExist());
-
-		verify(blockService).delete(blockId, 3, "user-123");
-	}
-
-    @Test
-    @DisplayName("실패_type이 없으면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsMissingType() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
+        verify(adminBlockTransactionService).applyReplaceContent(eq(blockId), any(), any(), eq("user-456"));
     }
 
     @Test
-    @DisplayName("실패_부모 블록이 없으면 블록 없음 응답을 반환한다")
-    void createBlockReturnsNotFoundWhenParentMissing() throws Exception {
-        UUID documentId = UUID.randomUUID();
-        UUID parentId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-
-        when(blockService.create(
-                eq(documentId),
-                eq(parentId),
-                eq(BlockType.TEXT),
-                eq(SIMPLE_CONTENT_SERIALIZED),
-                eq(null),
-                eq(null),
-                eq("user-123")
-        )).thenThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND));
-
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", documentId)
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": "11111111-1111-1111-1111-111111111111",
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9006, "요청한 블록을 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_인증 헤더가 없으면 블록 생성 API는 인증 오류를 반환한다")
-    void createBlockReturnsUnauthorizedWhenHeaderMissing() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_content가 없으면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsMissingContent() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT"
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_content format이 다르면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsUnsupportedContentFormat() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "plain_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_mark 타입이 허용 목록이 아니면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsUnsupportedMarkType() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": [
-                                          {
-                                            "type": "link",
-                                            "value": "https://example.com"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_textColor 값이 hex 형식이 아니면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsInvalidTextColor() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": [
-                                          {
-                                            "type": "textColor",
-                                            "value": "black"
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_같은 segment에 중복 mark 타입이 있으면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsDuplicateMarkType() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": [
-                                          { "type": "bold" },
-                                          { "type": "bold" }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_textColor 외 mark에 value가 있으면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsUnexpectedMarkValue() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": [
-                                          {
-                                            "type": "bold",
-                                            "value": true
-                                          }
-                                        ]
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_segment에 허용되지 않은 필드가 있으면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsUnexpectedSegmentField() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": [],
-                                        "extra": "field"
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_빈 segment가 중간에 섞여 있으면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsEmptySegmentInMultiSegmentContent() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "",
-                                        "marks": []
-                                      },
-                                      {
-                                        "text": "새 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("성공_segment가 1개뿐인 빈 블록은 유효성 검사에 통과한다")
-    void createBlockAllowsSingleEmptySegment() throws Exception {
+    @DisplayName("성공_삭제 API는 transaction delete 응답을 반환한다")
+    void deleteBlockDelegatesSingleDeleteTransaction() throws Exception {
         UUID documentId = UUID.randomUUID();
         UUID blockId = UUID.randomUUID();
-        Block createdBlock = block(
-                blockId,
-                documentId,
-                null,
-                "000000000001000000000000",
-                0,
-                ""
-        );
-        createdBlock.setContent("{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"\",\"marks\":[]}]}");
+        LocalDateTime deletedAt = LocalDateTime.of(2026, 3, 25, 12, 0);
+        when(adminBlockTransactionService.applyDelete(eq(blockId), any(), any(), eq("user-123")))
+                .thenReturn(transactionResult(documentId, null, blockId, null, null, deletedAt));
 
-        when(blockService.create(
-                eq(documentId),
-                eq(null),
-                eq(BlockType.TEXT),
-                eq("{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"\",\"marks\":[]}]}"),
-                eq(null),
-                eq(null),
-                eq("user-123")
-        )).thenReturn(createdBlock);
-
-        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", documentId)
+        mockMvc.perform(delete("/v1/admin/blocks/{blockId}", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
                                 {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-3",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_DELETE",
+                                      "blockRef": "%s",
+                                      "version": 3
+                                    }
+                                  ]
                                 }
-                                """))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.content.segments[0].text").value(""));
+                                """.formatted(blockId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.appliedOperations[0].blockId").value(blockId.toString()))
+                .andExpect(jsonPath("$.data.appliedOperations[0].deletedAt").exists());
+
+        verify(adminBlockTransactionService).applyDelete(eq(blockId), any(), any(), eq("user-123"));
     }
 
     @Test
-    @DisplayName("실패_content가 없으면 블록 수정 요청은 유효성 검사 오류를 반환한다")
-    void updateBlockRejectsMissingContent() throws Exception {
-        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "version": 0
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 블록이면 블록 없음 응답을 반환한다")
-    void updateBlockReturnsNotFoundWhenBlockMissing() throws Exception {
-        UUID blockId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-
-        when(blockService.update(eq(blockId), eq(UPDATED_CONTENT_SERIALIZED), eq(0), eq("user-123")))
-                .thenThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND));
-
-        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", blockId)
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "수정된 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  },
-                                  "version": 0
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9006, "요청한 블록을 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_인증 헤더가 없으면 블록 수정 API는 인증 오류를 반환한다")
-    void updateBlockReturnsUnauthorizedWhenHeaderMissing() throws Exception {
-        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", UUID.randomUUID())
-                        .contentType("application/json")
-                        .content("""
-                                {
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "수정된 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  },
-                                  "version": 0
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 블록 삭제 시 블록 없음 응답을 반환한다")
-    void deleteBlockReturnsNotFoundWhenBlockMissing() throws Exception {
+    @DisplayName("성공_이동 API는 transaction move 응답을 반환한다")
+    void moveBlockDelegatesSingleMoveTransaction() throws Exception {
         UUID blockId = UUID.randomUUID();
-        doThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND))
-                .when(blockService).delete(blockId, 3, "user-123");
-
-        var result = mockMvc.perform(delete("/v1/admin/blocks/{blockId}", blockId)
-                        .param("version", "3")
-                        .header("X-User-Id", "user-123"));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9006, "요청한 블록을 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_version 없이 블록 삭제를 요청하면 유효성 오류를 반환한다")
-    void deleteBlockReturnsBadRequestWhenVersionMissing() throws Exception {
-        var result = mockMvc.perform(delete("/v1/admin/blocks/{blockId}", UUID.randomUUID())
-                        .header("X-User-Id", "user-123"));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_인증 헤더가 없으면 블록 삭제 API는 인증 오류를 반환한다")
-    void deleteBlockReturnsUnauthorizedWhenHeaderMissing() throws Exception {
-        var result = mockMvc.perform(delete("/v1/admin/blocks/{blockId}", UUID.randomUUID())
-                        .param("version", "0"));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_version이 없으면 유효성 검사 오류를 반환한다")
-    void updateBlockRejectsMissingVersion() throws Exception {
-        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "수정된 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_version이 현재 블록 상태와 충돌하면 충돌 응답을 반환한다")
-    void updateBlockReturnsConflictWhenVersionMismatched() throws Exception {
-        UUID blockId = UUID.randomUUID();
-
-        when(blockService.update(eq(blockId), eq(UPDATED_CONTENT_SERIALIZED), eq(0), eq("user-123")))
-                .thenThrow(new BusinessException(BusinessErrorCode.CONFLICT));
-
-        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", blockId)
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "수정된 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  },
-                                  "version": 0
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "CONFLICT", 9005, "요청이 현재 리소스 상태와 충돌합니다.");
-    }
-
-    @Test
-    @DisplayName("성공_루트로 이동 요청 시 성공 응답을 반환한다")
-    void moveBlockReturnsSuccessEnvelopeForRootMove() throws Exception {
-        UUID blockId = UUID.randomUUID();
+        UUID documentId = UUID.randomUUID();
+        when(adminBlockTransactionService.applyMove(eq(blockId), any(), any(), eq("user-123")))
+                .thenReturn(transactionResult(documentId, null, blockId, 2, "000000000002000000000000", null));
 
         mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
                                 {
-                                  "parentId": null,
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 3
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-4",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_MOVE",
+                                      "blockRef": "%s",
+                                      "version": 1,
+                                      "parentRef": null,
+                                      "afterRef": null,
+                                      "beforeRef": null
+                                    }
+                                  ]
                                 }
-                                """))
+                                """.formatted(blockId)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("요청 응답 성공"))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data").doesNotExist());
+                .andExpect(jsonPath("$.data.appliedOperations[0].status").value("APPLIED"))
+                .andExpect(jsonPath("$.data.appliedOperations[0].sortKey").value("000000000002000000000000"));
 
-        verify(blockService).move(blockId, null, null, null, 3, "user-123");
+        verify(adminBlockTransactionService).applyMove(eq(blockId), any(), any(), eq("user-123"));
     }
 
     @Test
-    @DisplayName("성공_다른 부모 아래 특정 형제 뒤로 이동 요청 시 전달값을 그대로 서비스에 넘긴다")
-    void moveBlockPassesAnchorsToService() throws Exception {
+    @DisplayName("실패_단일 operation이 아니면 잘못된 요청을 반환한다")
+    void updateBlockRejectsMultipleOperations() throws Exception {
         UUID blockId = UUID.randomUUID();
-        UUID parentId = UUID.randomUUID();
-        UUID afterBlockId = UUID.randomUUID();
+        when(adminBlockTransactionService.applyReplaceContent(eq(blockId), any(), any(), eq("user-123")))
+                .thenThrow(new BusinessException(BusinessErrorCode.INVALID_REQUEST));
 
-        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
+        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", blockId)
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
                                 {
-                                  "parentId": "%s",
-                                  "afterBlockId": "%s",
-                                  "beforeBlockId": null,
-                                  "version": 4
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-5",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_REPLACE_CONTENT",
+                                      "blockRef": "%s",
+                                      "version": 0,
+                                      "content": {
+                                        "format": "rich_text",
+                                        "schemaVersion": 1,
+                                        "segments": [
+                                          {
+                                            "text": "A",
+                                            "marks": []
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    {
+                                      "opId": "op-2",
+                                      "type": "BLOCK_REPLACE_CONTENT",
+                                      "blockRef": "%s",
+                                      "version": 1,
+                                      "content": {
+                                        "format": "rich_text",
+                                        "schemaVersion": 1,
+                                        "segments": [
+                                          {
+                                            "text": "B",
+                                            "marks": []
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
                                 }
-                                """.formatted(parentId, afterBlockId)))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200));
-
-        verify(blockService).move(blockId, parentId, afterBlockId, null, 4, "user-123");
-    }
-
-    @Test
-    @DisplayName("실패_인증 헤더가 없으면 블록 이동 API는 인증 오류를 반환한다")
-    void moveBlockReturnsUnauthorizedWhenHeaderMissing() throws Exception {
-        UUID blockId = UUID.randomUUID();
-
-        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
-                        .contentType("application/json")
-                        .content("""
-                                {
-                                  "parentId": null,
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "UNAUTHORIZED", 9001, "인증 정보가 없습니다.");
-        verify(blockService, never()).move(any(), any(), any(), any(), any(), any());
-    }
-
-    @Test
-    @DisplayName("실패_version이 없으면 블록 이동 API는 유효성 검사 오류를 반환한다")
-    void moveBlockReturnsValidationErrorWhenVersionMissing() throws Exception {
-        UUID blockId = UUID.randomUUID();
-
-        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": null,
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9016, "요청 필드 유효성 검사에 실패했습니다.");
-        verify(blockService, never()).move(any(), any(), any(), any(), any(), any());
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 블록 이동 요청은 블록 없음 응답을 반환한다")
-    void moveBlockReturnsNotFoundWhenBlockMissing() throws Exception {
-        UUID blockId = UUID.randomUUID();
-        doThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND))
-                .when(blockService).move(blockId, null, null, null, 0, "user-123");
-
-        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": null,
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9006, "요청한 블록을 찾을 수 없습니다.");
-    }
-
-    @Test
-    @DisplayName("실패_version이 현재 블록 상태와 충돌하면 블록 이동 API는 충돌 응답을 반환한다")
-    void moveBlockReturnsConflictWhenVersionMismatched() throws Exception {
-        UUID blockId = UUID.randomUUID();
-        doThrow(new BusinessException(BusinessErrorCode.CONFLICT))
-                .when(blockService).move(blockId, null, null, null, 0, "user-123");
-
-        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": null,
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """));
-
-        ApiResponseAssertions.assertErrorEnvelope(result, "CONFLICT", 9005, "요청이 현재 리소스 상태와 충돌합니다.");
-    }
-
-    @Test
-    @DisplayName("실패_잘못된 위치 요청이면 블록 이동 API는 잘못된 요청 응답을 반환한다")
-    void moveBlockReturnsBadRequestWhenRequestInvalid() throws Exception {
-        UUID blockId = UUID.randomUUID();
-        doThrow(new BusinessException(BusinessErrorCode.INVALID_REQUEST))
-                .when(blockService).move(blockId, blockId, null, null, 0, "user-123");
-
-        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", blockId)
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": "%s",
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """.formatted(blockId)));
+                                """.formatted(blockId, blockId)));
 
         ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
     }
 
-    private Block block(UUID blockId, UUID documentId, UUID parentId, String sortKey, int version, String text) {
-        Block block = Block.builder()
-                .id(blockId)
-                .document(document(documentId))
-                .parent(parentId == null ? null : parentBlock(parentId, documentId))
-                .type(BlockType.TEXT)
-                .content(toContent(text))
-                .sortKey(sortKey)
-                .createdBy("user-123")
-                .updatedBy("user-123")
-                .build();
-        block.setVersion(version);
-        block.setCreatedAt(LocalDateTime.of(2026, 3, 17, 0, 0));
-        block.setUpdatedAt(LocalDateTime.of(2026, 3, 17, 0, 0));
-        return block;
+    @Test
+    @DisplayName("실패_path blockId와 blockRef가 다르면 잘못된 요청을 반환한다")
+    void updateBlockRejectsMismatchedBlockReference() throws Exception {
+        UUID blockId = UUID.randomUUID();
+        when(adminBlockTransactionService.applyReplaceContent(eq(blockId), any(), any(), eq("user-123")))
+                .thenThrow(new BusinessException(BusinessErrorCode.INVALID_REQUEST));
+
+        var result = mockMvc.perform(patch("/v1/admin/blocks/{blockId}", blockId)
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-6",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_REPLACE_CONTENT",
+                                      "blockRef": "%s",
+                                      "version": 0,
+                                      "content": {
+                                        "format": "rich_text",
+                                        "schemaVersion": 1,
+                                        "segments": [
+                                          {
+                                            "text": "수정",
+                                            "marks": []
+                                          }
+                                        ]
+                                      }
+                                    }
+                                  ]
+                                }
+                                """.formatted(UUID.randomUUID())));
+
+        ApiResponseAssertions.assertErrorEnvelope(result, "BAD_REQUEST", 9015, "잘못된 요청입니다.");
     }
 
-    private Document document(UUID documentId) {
-        return Document.builder()
-                .id(documentId)
-                .workspace(Workspace.builder()
-                        .id(UUID.randomUUID())
-                        .name("Docs Root")
-                        .build())
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build();
+    @Test
+    @DisplayName("실패_block 조회 실패는 그대로 전파한다")
+    void deleteBlockPropagatesBlockNotFound() throws Exception {
+        UUID blockId = UUID.randomUUID();
+        when(adminBlockTransactionService.applyDelete(eq(blockId), any(), any(), eq("user-123")))
+                .thenThrow(new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND));
+
+        var result = mockMvc.perform(delete("/v1/admin/blocks/{blockId}", blockId)
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-7",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_DELETE",
+                                      "blockRef": "%s",
+                                      "version": 0
+                                    }
+                                  ]
+                                }
+                                """.formatted(blockId)));
+
+        ApiResponseAssertions.assertErrorEnvelope(result, "NOT_FOUND", 9006, "요청한 블록을 찾을 수 없습니다.");
     }
 
-    private Block parentBlock(UUID blockId, UUID documentId) {
-        return Block.builder()
-                .id(blockId)
-                .document(document(documentId))
-                .type(BlockType.TEXT)
-                .content(toContent("부모 블록"))
-                .sortKey("000000000001000000000000")
-                .build();
-    }
-
-    private String toContent(String text) {
-        return "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"%s\",\"marks\":[]}]}".formatted(text);
+    private DocumentTransactionResult transactionResult(
+            UUID documentId,
+            String tempId,
+            UUID blockId,
+            Integer version,
+            String sortKey,
+            LocalDateTime deletedAt
+    ) {
+        return new DocumentTransactionResult(
+                documentId,
+                1,
+                "batch-1",
+                List.of(new DocumentTransactionAppliedOperationResult(
+                        "op-1",
+                        DocumentTransactionOperationStatus.APPLIED,
+                        tempId,
+                        blockId,
+                        version,
+                        sortKey,
+                        deletedAt
+                ))
+        );
     }
 }

--- a/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
+++ b/documents-boot/src/test/java/com/documents/api/block/BlockApiIntegrationTest.java
@@ -15,6 +15,8 @@ import com.documents.domain.Workspace;
 import com.documents.repository.BlockRepository;
 import com.documents.repository.DocumentRepository;
 import com.documents.repository.WorkspaceRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -28,9 +30,6 @@ import org.springframework.test.web.servlet.MockMvc;
 @AutoConfigureMockMvc
 @DisplayName("Block API 통합 검증")
 class BlockApiIntegrationTest {
-
-    private static final String SIMPLE_CONTENT_SERIALIZED = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"새 블록\",\"marks\":[]}]}";
-    private static final String UPDATED_CONTENT_SERIALIZED = "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"수정된 블록\",\"marks\":[]}]}";
 
     @Autowired
     private MockMvc mockMvc;
@@ -54,849 +53,239 @@ class BlockApiIntegrationTest {
     @Test
     @DisplayName("성공_문서 블록 목록 조회 API는 활성 블록 전체를 정렬 순서대로 반환한다")
     void getBlocksReturnsAllActiveBlocks() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block rootBlock = blockRepository.save(Block.builder()
-                .id(UUID.randomUUID())
-                .document(document)
-                .type(BlockType.TEXT)
-                .content(toContent("루트 블록"))
-                .sortKey("000000000001000000000000")
-                .createdBy("user-123")
-                .updatedBy("user-123")
-                .build());
-        blockRepository.save(Block.builder()
-                .id(UUID.randomUUID())
-                .document(document)
-                .parent(rootBlock)
-                .type(BlockType.TEXT)
-                .content(toContent("자식 블록"))
-                .sortKey("000000000001I00000000000")
-                .createdBy("user-123")
-                .updatedBy("user-123")
-                .build());
+        Document document = document("문서");
+        Block rootBlock = block(document, null, "루트 블록", "000000000001000000000000");
+        block(document, rootBlock, "자식 블록", "000000000001I00000000000");
         blockRepository.save(Block.builder()
                 .id(UUID.randomUUID())
                 .document(document)
                 .type(BlockType.TEXT)
-                .content(toContent("삭제된 블록"))
+                .content(content("삭제된 블록"))
                 .sortKey("000000000002000000000000")
                 .createdBy("user-123")
                 .updatedBy("user-123")
-                .deletedAt(java.time.LocalDateTime.of(2026, 3, 16, 0, 0))
+                .deletedAt(LocalDateTime.of(2026, 3, 16, 0, 0))
                 .build());
 
         mockMvc.perform(get("/v1/documents/{documentId}/blocks", document.getId()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.data.length()").value(2))
-                .andExpect(jsonPath("$.data[0].content.format").value("rich_text"))
                 .andExpect(jsonPath("$.data[0].content.segments[0].text").value("루트 블록"))
-                .andExpect(jsonPath("$.data[1].content.format").value("rich_text"))
                 .andExpect(jsonPath("$.data[1].content.segments[0].text").value("자식 블록"));
     }
 
     @Test
-    @DisplayName("성공_블록 생성 API는 문서 하위에 루트 텍스트 블록을 저장하고 응답한다")
-    void createBlockReturnsCreatedEnvelope() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
+    @DisplayName("성공_생성 admin API는 transaction create 응답을 그대로 반환한다")
+    void createBlockUsesTransactionContract() throws Exception {
+        Document document = document("문서");
 
-                mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", document.getId())
+        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", document.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
                                 {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-create",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_CREATE",
+                                      "blockRef": "tmp:block:1"
+                                    }
+                                  ]
                                 }
                                 """))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.httpStatus").value("CREATED"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.message").value("리소스 생성 성공"))
-                .andExpect(jsonPath("$.code").value(201))
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.documentId").value(document.getId().toString()))
-                .andExpect(jsonPath("$.data.parentId").doesNotExist())
-                .andExpect(jsonPath("$.data.type").value("TEXT"))
-                .andExpect(jsonPath("$.data.content.format").value("rich_text"))
-                .andExpect(jsonPath("$.data.content.schemaVersion").value(1))
-                .andExpect(jsonPath("$.data.content.segments[0].text").value("새 블록"))
-                .andExpect(jsonPath("$.data.content.segments[0].marks").isArray())
-                .andExpect(jsonPath("$.data.sortKey").value("000000000001000000000000"))
-                .andExpect(jsonPath("$.data.createdBy").value("user-123"))
-                .andExpect(jsonPath("$.data.version").value(0));
+                .andExpect(jsonPath("$.data.batchId").value("batch-create"))
+                .andExpect(jsonPath("$.data.appliedOperations[0].tempId").value("tmp:block:1"))
+                .andExpect(jsonPath("$.data.appliedOperations[0].status").value("APPLIED"));
 
-        assertThat(blockRepository.findAll()).hasSize(1);
-        Block saved = blockRepository.findAll().get(0);
-        assertThat(saved.getDocumentId()).isEqualTo(document.getId());
-        assertThat(saved.getParentId()).isNull();
-        assertThat(saved.getType()).isEqualTo(BlockType.TEXT);
-        assertThat(saved.getContent()).isEqualTo(SIMPLE_CONTENT_SERIALIZED);
-        assertThat(saved.getSortKey()).isEqualTo("000000000001000000000000");
-        assertThat(saved.getCreatedBy()).isEqualTo("user-123");
+        List<Block> blocks = blockRepository.findActiveByDocumentIdOrderBySortKey(document.getId());
+        assertThat(blocks).hasSize(1);
+        assertThat(blocks.get(0).getContent()).isEqualTo(emptyContent());
     }
 
     @Test
-    @DisplayName("성공_블록 수정 API는 블록 본문과 수정자를 갱신한다")
-    void updateBlockUpdatesTextAndActor() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block block = blockRepository.save(Block.builder()
-                .id(UUID.randomUUID())
-                .document(document)
-                .type(BlockType.TEXT)
-                .content(toContent("기존 블록"))
-                .sortKey("000000000001000000000000")
-                .createdBy("user-123")
-                .updatedBy("user-123")
-                .build());
+    @DisplayName("성공_수정 admin API는 transaction replace_content 경로로 같은 블록을 수정한다")
+    void updateBlockUsesTransactionContract() throws Exception {
+        Document document = document("문서");
+        Block block = block(document, null, "기존 블록", "000000000001000000000000");
 
         mockMvc.perform(patch("/v1/admin/blocks/{blockId}", block.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-456")
                         .content("""
                                 {
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "수정된 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  },
-                                  "version": 0
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.data.id").value(block.getId().toString()))
-                .andExpect(jsonPath("$.data.content.format").value("rich_text"))
-                .andExpect(jsonPath("$.data.content.schemaVersion").value(1))
-                .andExpect(jsonPath("$.data.content.segments[0].text").value("수정된 블록"))
-                .andExpect(jsonPath("$.data.updatedBy").value("user-456"))
-                .andExpect(jsonPath("$.data.version").value(1));
-
-        Block updated = blockRepository.findById(block.getId()).orElseThrow();
-        assertThat(updated.getContent()).isEqualTo(UPDATED_CONTENT_SERIALIZED);
-        assertThat(updated.getUpdatedBy()).isEqualTo("user-456");
-        assertThat(updated.getVersion()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("실패_블록 수정 API에 낡은 version이 오면 충돌 응답을 반환한다")
-    void updateBlockReturnsConflictWhenVersionMismatched() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block block = blockRepository.save(Block.builder()
-                .id(UUID.randomUUID())
-                .document(document)
-                .type(BlockType.TEXT)
-                .content(toContent("기존 블록"))
-                .sortKey("000000000001000000000000")
-                .createdBy("user-123")
-                .updatedBy("user-123")
-                .build());
-        block.setContent(toContent("다른 사용자 수정"));
-        blockRepository.save(block);
-
-        mockMvc.perform(patch("/v1/admin/blocks/{blockId}", block.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-456")
-                        .content("""
-                                {
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "수정된 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  },
-                                  "version": 0
-                                }
-                                """))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.httpStatus").value("CONFLICT"))
-                .andExpect(jsonPath("$.code").value(9005))
-                .andExpect(jsonPath("$.message").value("요청이 현재 리소스 상태와 충돌합니다."));
-    }
-
-    @Test
-    @DisplayName("성공_블록 삭제 API는 하위 블록까지 soft delete 처리하고 다른 블록은 보존한다")
-    void deleteBlockSoftDeletesDescendantsOnly() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block rootBlock = saveBlock(document, null, "삭제 대상 루트", "000000000001000000000000");
-        Block childBlock = saveBlock(document, rootBlock, "삭제 대상 자식", "000000000001I00000000000");
-        Block grandChildBlock = saveBlock(document, childBlock, "삭제 대상 손자", "000000000001Q00000000000");
-        Block otherRootBlock = saveBlock(document, null, "보존 대상", "000000000002000000000000");
-
-        mockMvc.perform(delete("/v1/admin/blocks/{blockId}", rootBlock.getId())
-                        .param("version", "0")
-                        .header("X-User-Id", "user-123"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200));
-
-        Block deletedRoot = blockRepository.findById(rootBlock.getId()).orElseThrow();
-        Block deletedChild = blockRepository.findById(childBlock.getId()).orElseThrow();
-        Block deletedGrandChild = blockRepository.findById(grandChildBlock.getId()).orElseThrow();
-        Block survivedBlock = blockRepository.findById(otherRootBlock.getId()).orElseThrow();
-
-        assertThat(deletedRoot.getDeletedAt()).isNotNull();
-        assertThat(deletedChild.getDeletedAt()).isNotNull();
-        assertThat(deletedGrandChild.getDeletedAt()).isNotNull();
-        assertThat(survivedBlock.getDeletedAt()).isNull();
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 블록을 삭제하면 블록 없음 응답을 반환한다")
-    void deleteBlockReturnsNotFoundWhenBlockMissing() throws Exception {
-        var result = mockMvc.perform(delete("/v1/admin/blocks/{blockId}", UUID.randomUUID())
-                        .param("version", "0")
-                        .header("X-User-Id", "user-123"));
-
-        result.andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
-                .andExpect(jsonPath("$.code").value(9006))
-                .andExpect(jsonPath("$.message").value("요청한 블록을 찾을 수 없습니다."));
-    }
-
-    @Test
-    @DisplayName("실패_삭제 version이 낡으면 충돌 응답을 반환한다")
-    void deleteBlockReturnsConflictWhenVersionIsStale() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block rootBlock = saveBlock(document, null, "삭제 대상 루트", "000000000001000000000000");
-
-        mockMvc.perform(delete("/v1/admin/blocks/{blockId}", rootBlock.getId())
-                        .param("version", "-1")
-                        .header("X-User-Id", "user-123"))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.httpStatus").value("CONFLICT"))
-                .andExpect(jsonPath("$.code").value(9005))
-                .andExpect(jsonPath("$.message").value("요청이 현재 리소스 상태와 충돌합니다."));
-    }
-
-    @Test
-    @DisplayName("성공_afterBlockId를 사용하면 기존 형제 사이 위치용 gap sortKey로 블록을 생성한다")
-    void createBlockInsertsBetweenSiblings() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block first = blockRepository.save(Block.builder()
-                .id(UUID.randomUUID())
-                .document(document)
-                .type(BlockType.TEXT)
-                .content(toContent("첫 블록"))
-                .sortKey("000000000001000000000000")
-                .createdBy("user-123")
-                .updatedBy("user-123")
-                .build());
-        Block second = blockRepository.save(Block.builder()
-                .id(UUID.randomUUID())
-                .document(document)
-                .type(BlockType.TEXT)
-                .content(toContent("둘째 블록"))
-                .sortKey("000000000002000000000000")
-                .createdBy("user-123")
-                .updatedBy("user-123")
-                .build());
-
-        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", document.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "중간 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  },
-                                  "afterBlockId": "%s"
-                                }
-                                """.formatted(first.getId())))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.sortKey").value("000000000001I00000000000"));
-
-        Block reloadedSecond = blockRepository.findById(second.getId()).orElseThrow();
-        assertThat(reloadedSecond.getSortKey()).isEqualTo("000000000002000000000000");
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 문서로 블록을 생성하면 문서 없음 응답을 반환한다")
-    void createBlockReturnsNotFoundWhenDocumentMissing() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": []
-                                      }
-                                    ]
-                                  }
-                                }
-                                """));
-
-        result.andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
-                .andExpect(jsonPath("$.code").value(9004))
-                .andExpect(jsonPath("$.message").value("요청한 문서를 찾을 수 없습니다."));
-    }
-
-    @Test
-    @DisplayName("성공_루트 블록을 다른 루트 위치로 재정렬하면 sortKey와 updatedBy와 version이 변경된다")
-    void moveRootBlockReordersAmongRootBlocks() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block first = saveBlock(document, null, "첫 블록", "000000000001000000000000");
-        Block moved = saveBlock(document, null, "이동 대상", "000000000002000000000000");
-        Block third = saveBlock(document, null, "셋째 블록", "000000000003000000000000");
-
-        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-456")
-                        .content("""
-                                {
-                                  "parentId": null,
-                                  "afterBlockId": "%s",
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """.formatted(third.getId())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200));
-
-        Block reloaded = blockRepository.findById(moved.getId()).orElseThrow();
-        assertThat(reloaded.getParentId()).isNull();
-        assertThat(reloaded.getSortKey()).isEqualTo("000000000004000000000000");
-        assertThat(reloaded.getUpdatedBy()).isEqualTo("user-456");
-        assertThat(reloaded.getVersion()).isEqualTo(1);
-        assertThat(blockRepository.findById(first.getId()).orElseThrow().getSortKey())
-                .isEqualTo("000000000001000000000000");
-    }
-
-    @Test
-    @DisplayName("성공_블록을 다른 부모 블록 아래로 이동하면 parentId와 sortKey가 함께 변경된다")
-    void moveBlockToAnotherParent() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block parent = saveBlock(document, null, "대상 부모", "000000000001000000000000");
-        saveBlock(document, parent, "기존 자식", "000000000001000000000000");
-        Block moved = saveBlock(document, null, "이동 대상", "000000000002000000000000");
-
-        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-456")
-                        .content("""
-                                {
-                                  "parentId": "%s",
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """.formatted(parent.getId())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200));
-
-        Block reloaded = blockRepository.findById(moved.getId()).orElseThrow();
-        assertThat(reloaded.getParentId()).isEqualTo(parent.getId());
-        assertThat(reloaded.getSortKey()).isEqualTo("000000000002000000000000");
-        assertThat(reloaded.getUpdatedBy()).isEqualTo("user-456");
-        assertThat(reloaded.getVersion()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("성공_same parent 내 afterBlockId 기준 이동이 반영된다")
-    void moveBlockWithinSameParentUsingAfterAnchor() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block parent = saveBlock(document, null, "부모", "000000000001000000000000");
-        Block first = saveBlock(document, parent, "첫 자식", "000000000001000000000000");
-        Block second = saveBlock(document, parent, "둘째 자식", "000000000002000000000000");
-        Block moved = saveBlock(document, parent, "이동 대상", "000000000003000000000000");
-
-        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-456")
-                        .content("""
-                                {
-                                  "parentId": "%s",
-                                  "afterBlockId": "%s",
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """.formatted(parent.getId(), first.getId())))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.httpStatus").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.code").value(200));
-
-        Block reloaded = blockRepository.findById(moved.getId()).orElseThrow();
-        assertThat(reloaded.getParentId()).isEqualTo(parent.getId());
-        assertThat(reloaded.getSortKey()).isEqualTo("000000000001I00000000000");
-        assertThat(reloaded.getUpdatedBy()).isEqualTo("user-456");
-        assertThat(blockRepository.findById(second.getId()).orElseThrow().getSortKey())
-                .isEqualTo("000000000002000000000000");
-    }
-
-    @Test
-    @DisplayName("실패_존재하지 않는 블록 이동은 블록 없음 응답을 반환한다")
-    void moveBlockReturnsNotFoundWhenBlockMissing() throws Exception {
-        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", UUID.randomUUID())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": null,
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """));
-
-        result.andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
-                .andExpect(jsonPath("$.code").value(9006))
-                .andExpect(jsonPath("$.message").value("요청한 블록을 찾을 수 없습니다."));
-    }
-
-    @Test
-    @DisplayName("실패_삭제된 블록 이동은 블록 없음 응답을 반환한다")
-    void moveBlockReturnsNotFoundWhenBlockDeleted() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block deleted = blockRepository.save(Block.builder()
-                .id(UUID.randomUUID())
-                .document(document)
-                .type(BlockType.TEXT)
-                .content(toContent("삭제 블록"))
-                .sortKey("000000000001000000000000")
-                .createdBy("user-123")
-                .updatedBy("user-123")
-                .deletedAt(java.time.LocalDateTime.of(2026, 3, 20, 0, 0))
-                .build());
-
-        var result = mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", deleted.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": null,
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """));
-
-        result.andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.httpStatus").value("NOT_FOUND"))
-                .andExpect(jsonPath("$.code").value(9006))
-                .andExpect(jsonPath("$.message").value("요청한 블록을 찾을 수 없습니다."));
-    }
-
-    @Test
-    @DisplayName("실패_블록 이동 API에 낡은 version이 오면 충돌 응답을 반환한다")
-    void moveBlockReturnsConflictWhenVersionMismatched() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block block = saveBlock(document, null, "이동 대상", "000000000001000000000000");
-        block.setContent(toContent("다른 사용자 수정"));
-        blockRepository.save(block);
-
-        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", block.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-456")
-                        .content("""
-                                {
-                                  "parentId": null,
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.httpStatus").value("CONFLICT"))
-                .andExpect(jsonPath("$.code").value(9005))
-                .andExpect(jsonPath("$.message").value("요청이 현재 리소스 상태와 충돌합니다."));
-    }
-
-    @Test
-    @DisplayName("실패_자기 자신을 부모로 지정하면 잘못된 요청 응답을 반환한다")
-    void moveBlockReturnsBadRequestWhenParentIsSelf() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block block = saveBlock(document, null, "이동 대상", "000000000001000000000000");
-
-        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", block.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": "%s",
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """.formatted(block.getId())))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.code").value(9015))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
-    }
-
-    @Test
-    @DisplayName("실패_하위 블록을 부모로 지정하면 잘못된 요청 응답을 반환한다")
-    void moveBlockReturnsBadRequestWhenParentIsDescendant() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block root = saveBlock(document, null, "루트", "000000000001000000000000");
-        Block child = saveBlock(document, root, "자식", "000000000001000000000000");
-
-        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", root.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": "%s",
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """.formatted(child.getId())))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.code").value(9015))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
-    }
-
-    @Test
-    @DisplayName("실패_최대 깊이를 넘기는 부모로 블록 이동 요청 시 잘못된 요청 응답을 반환한다")
-    void moveBlockReturnsBadRequestWhenTargetParentDepthExceedsLimit() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Block depth1 = saveBlock(document, null, "1", "000000000001000000000000");
-        Block depth2 = saveBlock(document, depth1, "2", "000000000001000000000000");
-        Block depth3 = saveBlock(document, depth2, "3", "000000000001000000000000");
-        Block depth4 = saveBlock(document, depth3, "4", "000000000001000000000000");
-        Block depth5 = saveBlock(document, depth4, "5", "000000000001000000000000");
-        Block depth6 = saveBlock(document, depth5, "6", "000000000001000000000000");
-        Block depth7 = saveBlock(document, depth6, "7", "000000000001000000000000");
-        Block depth8 = saveBlock(document, depth7, "8", "000000000001000000000000");
-        Block depth9 = saveBlock(document, depth8, "9", "000000000001000000000000");
-        Block depth10 = saveBlock(document, depth9, "10", "000000000001000000000000");
-        Block moved = saveBlock(document, null, "이동 대상", "000000000002000000000000");
-
-        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": "%s",
-                                  "afterBlockId": null,
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """.formatted(depth10.getId())))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.code").value(9015))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
-    }
-
-    @Test
-    @DisplayName("실패_다른 문서의 블록을 부모나 anchor로 사용하면 잘못된 요청 응답을 반환한다")
-    void moveBlockReturnsBadRequestWhenParentOrAnchorBelongsToOtherDocument() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document sourceDocument = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("원본 문서")
-                .sortKey("00000000000000000001")
-                .build());
-        Document otherDocument = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("다른 문서")
-                .sortKey("00000000000000000002")
-                .build());
-        Block moved = saveBlock(sourceDocument, null, "이동 대상", "000000000001000000000000");
-        Block otherParent = saveBlock(otherDocument, null, "다른 부모", "000000000001000000000000");
-        Block otherAnchor = saveBlock(otherDocument, null, "다른 anchor", "000000000002000000000000");
-
-        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "parentId": "%s",
-                                  "afterBlockId": "%s",
-                                  "beforeBlockId": null,
-                                  "version": 0
-                                }
-                                """.formatted(otherParent.getId(), otherAnchor.getId())))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.code").value(9015))
-                .andExpect(jsonPath("$.message").value("잘못된 요청입니다."));
-    }
-
-    @Test
-    @DisplayName("실패_블록 생성 API에 허용되지 않은 mark가 오면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsUnsupportedMarkType() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
-
-        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", document.getId())
-                        .contentType("application/json")
-                        .header("X-User-Id", "user-123")
-                        .content("""
-                                {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": [
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-update",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_REPLACE_CONTENT",
+                                      "blockRef": "%s",
+                                      "version": 0,
+                                      "content": {
+                                        "format": "rich_text",
+                                        "schemaVersion": 1,
+                                        "segments": [
                                           {
-                                            "type": "link",
-                                            "value": "https://example.com"
+                                            "text": "수정된 블록",
+                                            "marks": []
                                           }
                                         ]
                                       }
-                                    ]
-                                  }
+                                    }
+                                  ]
                                 }
-                                """))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.code").value(9016))
-                .andExpect(jsonPath("$.message").value("요청 필드 유효성 검사에 실패했습니다."));
+                                """.formatted(block.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.documentId").value(document.getId().toString()))
+                .andExpect(jsonPath("$.data.appliedOperations[0].blockId").value(block.getId().toString()))
+                .andExpect(jsonPath("$.data.appliedOperations[0].version").value(1))
+                .andExpect(jsonPath("$.data.appliedOperations[0].status").value("APPLIED"));
+
+        Block updated = blockRepository.findByIdAndDeletedAtIsNull(block.getId()).orElseThrow();
+        assertThat(updated.getContent()).isEqualTo(content("수정된 블록"));
+        assertThat(updated.getUpdatedBy()).isEqualTo("user-456");
     }
 
     @Test
-    @DisplayName("실패_블록 생성 API에 중복 mark 타입이 오면 유효성 검사 오류를 반환한다")
-    void createBlockRejectsDuplicateMarkType() throws Exception {
-        Workspace workspace = workspaceRepository.save(Workspace.builder()
-                .id(UUID.randomUUID())
-                .name("Docs Root")
-                .build());
-        Document document = documentRepository.save(Document.builder()
-                .id(UUID.randomUUID())
-                .workspace(workspace)
-                .title("문서")
-                .sortKey("00000000000000000001")
-                .build());
+    @DisplayName("성공_이동 admin API는 transaction move 경로로 같은 블록을 이동한다")
+    void moveBlockUsesTransactionContract() throws Exception {
+        Document document = document("문서");
+        Block targetParent = block(document, null, "부모 블록", "000000000001000000000000");
+        Block moved = block(document, null, "이동 블록", "000000000002000000000000");
 
-        mockMvc.perform(post("/v1/admin/documents/{documentId}/blocks", document.getId())
+        mockMvc.perform(post("/v1/admin/blocks/{blockId}/move", moved.getId())
                         .contentType("application/json")
                         .header("X-User-Id", "user-123")
                         .content("""
                                 {
-                                  "type": "TEXT",
-                                  "content": {
-                                    "format": "rich_text",
-                                    "schemaVersion": 1,
-                                    "segments": [
-                                      {
-                                        "text": "새 블록",
-                                        "marks": [
-                                          { "type": "bold" },
-                                          { "type": "bold" }
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-move",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_MOVE",
+                                      "blockRef": "%s",
+                                      "version": 0,
+                                      "parentRef": "%s"
+                                    }
+                                  ]
+                                }
+                                """.formatted(moved.getId(), targetParent.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.appliedOperations[0].status").value("APPLIED"))
+                .andExpect(jsonPath("$.data.appliedOperations[0].blockId").value(moved.getId().toString()));
+
+        Block reloaded = blockRepository.findByIdAndDeletedAtIsNull(moved.getId()).orElseThrow();
+        assertThat(reloaded.getParentId()).isEqualTo(targetParent.getId());
+    }
+
+    @Test
+    @DisplayName("성공_삭제 admin API는 transaction delete 경로로 subtree soft delete를 수행한다")
+    void deleteBlockUsesTransactionContract() throws Exception {
+        Document document = document("문서");
+        Block root = block(document, null, "루트 블록", "000000000001000000000000");
+        Block child = block(document, root, "자식 블록", "000000000001I00000000000");
+
+        mockMvc.perform(delete("/v1/admin/blocks/{blockId}", root.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-delete",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_DELETE",
+                                      "blockRef": "%s",
+                                      "version": 0
+                                    }
+                                  ]
+                                }
+                                """.formatted(root.getId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.appliedOperations[0].status").value("APPLIED"))
+                .andExpect(jsonPath("$.data.appliedOperations[0].blockId").value(root.getId().toString()))
+                .andExpect(jsonPath("$.data.appliedOperations[0].deletedAt").exists());
+
+        assertThat(blockRepository.findByIdAndDeletedAtIsNull(root.getId())).isEmpty();
+        assertThat(blockRepository.findByIdAndDeletedAtIsNull(child.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("실패_path blockId와 body blockRef가 다르면 잘못된 요청을 반환한다")
+    void updateBlockRejectsMismatchedBlockReference() throws Exception {
+        Block block = block(document("문서"), null, "기존 블록", "000000000001000000000000");
+
+        mockMvc.perform(patch("/v1/admin/blocks/{blockId}", block.getId())
+                        .contentType("application/json")
+                        .header("X-User-Id", "user-123")
+                        .content("""
+                                {
+                                  "clientId": "admin-api",
+                                  "batchId": "batch-invalid",
+                                  "operations": [
+                                    {
+                                      "opId": "op-1",
+                                      "type": "BLOCK_REPLACE_CONTENT",
+                                      "blockRef": "%s",
+                                      "version": 0,
+                                      "content": {
+                                        "format": "rich_text",
+                                        "schemaVersion": 1,
+                                        "segments": [
+                                          {
+                                            "text": "수정",
+                                            "marks": []
+                                          }
                                         ]
                                       }
-                                    ]
-                                  }
+                                    }
+                                  ]
                                 }
-                                """))
+                                """.formatted(UUID.randomUUID())))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.httpStatus").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.code").value(9016))
-                .andExpect(jsonPath("$.message").value("요청 필드 유효성 검사에 실패했습니다."));
+                .andExpect(jsonPath("$.code").value(9015));
     }
 
-    private String toContent(String text) {
-        return "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"%s\",\"marks\":[]}]}".formatted(text);
+    private Document document(String title) {
+        Workspace workspace = workspaceRepository.save(Workspace.builder()
+                .id(UUID.randomUUID())
+                .name("Docs Root")
+                .build());
+        return documentRepository.save(Document.builder()
+                .id(UUID.randomUUID())
+                .workspace(workspace)
+                .title(title)
+                .sortKey("00000000000000000001")
+                .createdBy("user-123")
+                .updatedBy("user-123")
+                .build());
     }
 
-    private Block saveBlock(Document document, Block parent, String text, String sortKey) {
+    private Block block(Document document, Block parent, String text, String sortKey) {
         return blockRepository.save(Block.builder()
                 .id(UUID.randomUUID())
                 .document(document)
                 .parent(parent)
                 .type(BlockType.TEXT)
-                .content(toContent(text))
+                .content(content(text))
                 .sortKey(sortKey)
                 .createdBy("user-123")
                 .updatedBy("user-123")
                 .build());
+    }
+
+    private String content(String text) {
+        return "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"%s\",\"marks\":[]}]}".formatted(text);
+    }
+
+    private String emptyContent() {
+        return "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"\",\"marks\":[]}]}";
     }
 }

--- a/documents-core/src/main/java/com/documents/service/AdminBlockTransactionService.java
+++ b/documents-core/src/main/java/com/documents/service/AdminBlockTransactionService.java
@@ -1,0 +1,37 @@
+package com.documents.service;
+
+import java.util.UUID;
+
+import com.documents.service.transaction.DocumentTransactionOperationCommand;
+import com.documents.service.transaction.DocumentTransactionResult;
+
+public interface AdminBlockTransactionService {
+
+    DocumentTransactionResult applyCreate(
+            UUID documentId,
+            String batchId,
+            DocumentTransactionOperationCommand operation,
+            String actorId
+    );
+
+    DocumentTransactionResult applyReplaceContent(
+            UUID blockId,
+            String batchId,
+            DocumentTransactionOperationCommand operation,
+            String actorId
+    );
+
+    DocumentTransactionResult applyMove(
+            UUID blockId,
+            String batchId,
+            DocumentTransactionOperationCommand operation,
+            String actorId
+    );
+
+    DocumentTransactionResult applyDelete(
+            UUID blockId,
+            String batchId,
+            DocumentTransactionOperationCommand operation,
+            String actorId
+    );
+}

--- a/documents-core/src/main/java/com/documents/service/BlockService.java
+++ b/documents-core/src/main/java/com/documents/service/BlockService.java
@@ -11,6 +11,8 @@ import com.documents.domain.Document;
 public interface BlockService {
     List<Block> getAllByDocumentId(UUID documentId);
 
+    Block getById(UUID blockId);
+
     Block create(
             UUID documentId,
             UUID parentId,

--- a/documents-core/src/main/java/com/documents/service/transaction/DocumentTransactionContext.java
+++ b/documents-core/src/main/java/com/documents/service/transaction/DocumentTransactionContext.java
@@ -1,0 +1,33 @@
+package com.documents.service.transaction;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class DocumentTransactionContext {
+
+    private final Map<String, BlockReferenceState> blockReferenceStates = new HashMap<>();
+
+    public boolean contains(String blockReference) {
+        return blockReferenceStates.containsKey(blockReference);
+    }
+
+    public BlockReferenceState get(String blockReference) {
+        return blockReferenceStates.get(blockReference);
+    }
+
+    public void put(String blockReference, UUID realBlockId, Integer currentVersion, Integer clientVersion, boolean temporary) {
+        blockReferenceStates.put(
+                blockReference,
+                new BlockReferenceState(realBlockId, currentVersion, clientVersion, temporary)
+        );
+    }
+
+    public record BlockReferenceState(
+            UUID realBlockId,
+            Integer currentVersion,
+            Integer clientVersion,
+            boolean temporary
+    ) {
+    }
+}

--- a/documents-infrastructure/src/main/java/com/documents/service/AdminBlockTransactionServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/AdminBlockTransactionServiceImpl.java
@@ -1,0 +1,138 @@
+package com.documents.service;
+
+import static com.documents.service.transaction.DocumentTransactionOperationStatus.APPLIED;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.documents.domain.Block;
+import com.documents.domain.Document;
+import com.documents.exception.BusinessErrorCode;
+import com.documents.exception.BusinessException;
+import com.documents.repository.DocumentRepository;
+import com.documents.service.transaction.DocumentTransactionAppliedOperationResult;
+import com.documents.service.transaction.DocumentTransactionContext;
+import com.documents.service.transaction.DocumentTransactionOperationCommand;
+import com.documents.service.transaction.DocumentTransactionOperationType;
+import com.documents.service.transaction.DocumentTransactionResult;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AdminBlockTransactionServiceImpl implements AdminBlockTransactionService {
+
+    private final BlockService blockService;
+    private final DocumentRepository documentRepository;
+    private final DocumentTransactionOperationExecutor operationExecutor;
+
+    @Override
+    @Transactional
+    public DocumentTransactionResult applyCreate(
+            UUID documentId,
+            String batchId,
+            DocumentTransactionOperationCommand operation,
+            String actorId
+    ) {
+        Document document = findActiveDocument(documentId);
+        validateOperationType(operation, DocumentTransactionOperationType.BLOCK_CREATE);
+        return applySingleOperation(documentId, document, batchId, operation, actorId);
+    }
+
+    @Override
+    @Transactional
+    public DocumentTransactionResult applyReplaceContent(
+            UUID blockId,
+            String batchId,
+            DocumentTransactionOperationCommand operation,
+            String actorId
+    ) {
+        Block block = blockService.getById(blockId);
+        validateOperationType(operation, DocumentTransactionOperationType.BLOCK_REPLACE_CONTENT);
+        validateBlockReferenceMatches(blockId, operation);
+        Document document = findActiveDocument(block.getDocumentId());
+        return applySingleOperation(document.getId(), document, batchId, operation, actorId);
+    }
+
+    @Override
+    @Transactional
+    public DocumentTransactionResult applyMove(
+            UUID blockId,
+            String batchId,
+            DocumentTransactionOperationCommand operation,
+            String actorId
+    ) {
+        Block block = blockService.getById(blockId);
+        validateOperationType(operation, DocumentTransactionOperationType.BLOCK_MOVE);
+        validateBlockReferenceMatches(blockId, operation);
+        Document document = findActiveDocument(block.getDocumentId());
+        return applySingleOperation(document.getId(), document, batchId, operation, actorId);
+    }
+
+    @Override
+    @Transactional
+    public DocumentTransactionResult applyDelete(
+            UUID blockId,
+            String batchId,
+            DocumentTransactionOperationCommand operation,
+            String actorId
+    ) {
+        Block block = blockService.getById(blockId);
+        validateOperationType(operation, DocumentTransactionOperationType.BLOCK_DELETE);
+        validateBlockReferenceMatches(blockId, operation);
+        Document document = findActiveDocument(block.getDocumentId());
+        return applySingleOperation(document.getId(), document, batchId, operation, actorId);
+    }
+
+    private DocumentTransactionResult applySingleOperation(
+            UUID documentId,
+            Document document,
+            String batchId,
+            DocumentTransactionOperationCommand operation,
+            String actorId
+    ) {
+        DocumentTransactionAppliedOperationResult appliedOperation = DocumentVersionIncrementContext.runWithoutIncrement(
+                () -> operationExecutor.apply(documentId, document, operation, actorId, new DocumentTransactionContext())
+        );
+
+        Integer documentVersion = document.getVersion();
+        if (appliedOperation.status() == APPLIED) {
+            documentVersion = incrementDocumentVersion(documentId, actorId);
+        }
+
+        return new DocumentTransactionResult(documentId, documentVersion, batchId, List.of(appliedOperation));
+    }
+
+    private void validateOperationType(
+            DocumentTransactionOperationCommand operation,
+            DocumentTransactionOperationType expectedType
+    ) {
+        if (operation == null || operation.type() != expectedType) {
+            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private void validateBlockReferenceMatches(UUID blockId, DocumentTransactionOperationCommand operation) {
+        if (!blockId.toString().equals(operation.blockReference())) {
+            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private Document findActiveDocument(UUID documentId) {
+        return documentRepository.findByIdAndDeletedAtIsNull(documentId)
+                .orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
+    }
+
+    private Integer incrementDocumentVersion(UUID documentId, String actorId) {
+        int updatedRowCount = documentRepository.incrementVersion(documentId, actorId, LocalDateTime.now());
+        if (updatedRowCount != 1) {
+            throw new BusinessException(BusinessErrorCode.CONFLICT);
+        }
+
+        return findActiveDocument(documentId).getVersion();
+    }
+}

--- a/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/BlockServiceImpl.java
@@ -44,6 +44,12 @@ public class BlockServiceImpl implements BlockService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public Block getById(UUID blockId) {
+        return findActiveBlock(blockId);
+    }
+
+    @Override
     @Transactional
     public Block create(
             UUID documentId,
@@ -347,4 +353,5 @@ public class BlockServiceImpl implements BlockService {
     private void incrementActiveDocumentVersion(UUID documentId, String actorId) {
         incrementActiveDocumentVersion(documentId, actorId, LocalDateTime.now());
     }
+
 }

--- a/documents-infrastructure/src/main/java/com/documents/service/DocumentTransactionOperationExecutor.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/DocumentTransactionOperationExecutor.java
@@ -1,0 +1,317 @@
+package com.documents.service;
+
+import static com.documents.service.transaction.DocumentTransactionOperationStatus.APPLIED;
+import static com.documents.service.transaction.DocumentTransactionOperationStatus.NO_OP;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Component;
+
+import com.documents.domain.Block;
+import com.documents.domain.BlockType;
+import com.documents.domain.Document;
+import com.documents.exception.BusinessErrorCode;
+import com.documents.exception.BusinessException;
+import com.documents.repository.BlockRepository;
+import com.documents.service.transaction.DocumentTransactionAppliedOperationResult;
+import com.documents.service.transaction.DocumentTransactionContext;
+import com.documents.service.transaction.DocumentTransactionOperationCommand;
+import com.documents.service.transaction.DocumentTransactionOperationStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class DocumentTransactionOperationExecutor {
+
+    private static final String EMPTY_TEXT_BLOCK_CONTENT =
+            "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"\",\"marks\":[]}]}";
+
+    private final BlockService blockService;
+    private final BlockRepository blockRepository;
+
+    public DocumentTransactionAppliedOperationResult apply(
+            UUID documentId,
+            Document document,
+            DocumentTransactionOperationCommand operation,
+            String actorId,
+            DocumentTransactionContext context
+    ) {
+        return switch (operation.type()) {
+            case BLOCK_CREATE -> applyCreate(document, operation, actorId, context);
+            case BLOCK_REPLACE_CONTENT -> applyReplaceContent(documentId, operation, actorId, context);
+            case BLOCK_MOVE -> applyMove(documentId, operation, actorId, context);
+            case BLOCK_DELETE -> applyDelete(documentId, operation, actorId, context);
+        };
+    }
+
+    private DocumentTransactionAppliedOperationResult applyCreate(
+            Document document,
+            DocumentTransactionOperationCommand operation,
+            String actorId,
+            DocumentTransactionContext context
+    ) {
+        validateBlockReferenceIsUnique(operation.blockReference(), context);
+        ResolvedPositionReferences resolvedPositionReferences = resolvePositionReferences(operation, context);
+
+        Block createdBlock = blockService.create(
+                document,
+                resolvedPositionReferences.parentId(),
+                BlockType.TEXT,
+                EMPTY_TEXT_BLOCK_CONTENT,
+                resolvedPositionReferences.afterBlockId(),
+                resolvedPositionReferences.beforeBlockId(),
+                actorId
+        );
+        blockRepository.flush();
+
+        context.put(operation.blockReference(), createdBlock.getId(), createdBlock.getVersion(), null, true);
+
+        return new DocumentTransactionAppliedOperationResult(
+                operation.opId(),
+                APPLIED,
+                operation.blockReference(),
+                createdBlock.getId(),
+                createdBlock.getVersion(),
+                createdBlock.getSortKey(),
+                null
+        );
+    }
+
+    private DocumentTransactionAppliedOperationResult applyReplaceContent(
+            UUID documentId,
+            DocumentTransactionOperationCommand operation,
+            String actorId,
+            DocumentTransactionContext context
+    ) {
+        ResolvedBlockReference resolvedBlockReference = resolveBlockReference(documentId, operation, context);
+        Block updatedBlock = blockService.update(
+                resolvedBlockReference.realBlockId(),
+                operation.content(),
+                resolvedBlockReference.version(),
+                actorId
+        );
+        blockRepository.flush();
+
+        context.put(
+                operation.blockReference(),
+                updatedBlock.getId(),
+                updatedBlock.getVersion(),
+                resolvedBlockReference.clientVersion(),
+                resolvedBlockReference.temporary()
+        );
+
+        return new DocumentTransactionAppliedOperationResult(
+                operation.opId(),
+                resolveAppliedStatus(resolvedBlockReference.version(), updatedBlock),
+                null,
+                updatedBlock.getId(),
+                updatedBlock.getVersion(),
+                updatedBlock.getSortKey(),
+                null
+        );
+    }
+
+    private DocumentTransactionAppliedOperationResult applyMove(
+            UUID documentId,
+            DocumentTransactionOperationCommand operation,
+            String actorId,
+            DocumentTransactionContext context
+    ) {
+        ResolvedBlockReference resolvedBlockReference = resolveBlockReference(documentId, operation, context);
+        ResolvedPositionReferences resolvedPositionReferences = resolvePositionReferences(operation, context);
+
+        Block movedBlock = blockService.move(
+                resolvedBlockReference.realBlockId(),
+                resolvedPositionReferences.parentId(),
+                resolvedPositionReferences.afterBlockId(),
+                resolvedPositionReferences.beforeBlockId(),
+                resolvedBlockReference.version(),
+                actorId
+        );
+        blockRepository.flush();
+
+        context.put(
+                operation.blockReference(),
+                movedBlock.getId(),
+                movedBlock.getVersion(),
+                resolvedBlockReference.clientVersion(),
+                resolvedBlockReference.temporary()
+        );
+
+        return new DocumentTransactionAppliedOperationResult(
+                operation.opId(),
+                resolveAppliedStatus(resolvedBlockReference.version(), movedBlock),
+                null,
+                movedBlock.getId(),
+                movedBlock.getVersion(),
+                movedBlock.getSortKey(),
+                null
+        );
+    }
+
+    private DocumentTransactionAppliedOperationResult applyDelete(
+            UUID documentId,
+            DocumentTransactionOperationCommand operation,
+            String actorId,
+            DocumentTransactionContext context
+    ) {
+        Block block = resolveExistingBlock(documentId, operation, context);
+        Block deletedBlock = blockService.delete(block.getId(), block.getVersion(), actorId);
+        blockRepository.flush();
+
+        return new DocumentTransactionAppliedOperationResult(
+                operation.opId(),
+                APPLIED,
+                null,
+                deletedBlock.getId(),
+                null,
+                null,
+                deletedBlock.getDeletedAt()
+        );
+    }
+
+    private ResolvedPositionReferences resolvePositionReferences(
+            DocumentTransactionOperationCommand operation,
+            DocumentTransactionContext context
+    ) {
+        return new ResolvedPositionReferences(
+                resolveOptionalBlockReference(operation.parentReference(), context),
+                resolveOptionalBlockReference(operation.afterReference(), context),
+                resolveOptionalBlockReference(operation.beforeReference(), context)
+        );
+    }
+
+    private ResolvedBlockReference resolveBlockReference(
+            UUID documentId,
+            DocumentTransactionOperationCommand operation,
+            DocumentTransactionContext context
+    ) {
+        DocumentTransactionContext.BlockReferenceState state = context.get(operation.blockReference());
+        if (state != null) {
+            validateRepeatedReferenceVersion(operation.version(), state);
+            return new ResolvedBlockReference(
+                    state.realBlockId(),
+                    state.currentVersion(),
+                    state.clientVersion(),
+                    state.temporary()
+            );
+        }
+
+        Block block = resolveFirstExistingBlock(documentId, operation);
+        return new ResolvedBlockReference(block.getId(), block.getVersion(), operation.version(), false);
+    }
+
+    private void validateBlockReferenceIsUnique(String blockReference, DocumentTransactionContext context) {
+        if (context.contains(blockReference)) {
+            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private UUID resolveOptionalBlockReference(String blockReference, DocumentTransactionContext context) {
+        if (blockReference == null || blockReference.isBlank()) {
+            return null;
+        }
+
+        DocumentTransactionContext.BlockReferenceState state = context.get(blockReference);
+        if (state != null) {
+            return state.realBlockId();
+        }
+
+        return parseRealBlockId(blockReference);
+    }
+
+    private UUID parseRealBlockId(String blockReference) {
+        try {
+            return UUID.fromString(blockReference);
+        } catch (IllegalArgumentException ex) {
+            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private Block resolveExistingBlock(
+            UUID documentId,
+            DocumentTransactionOperationCommand operation,
+            DocumentTransactionContext context
+    ) {
+        DocumentTransactionContext.BlockReferenceState state = context.get(operation.blockReference());
+        if (state != null) {
+            return resolveExistingBlockFromContext(documentId, operation, state);
+        }
+
+        return resolveFirstExistingBlock(documentId, operation);
+    }
+
+    private Block resolveExistingBlockFromContext(
+            UUID documentId,
+            DocumentTransactionOperationCommand operation,
+            DocumentTransactionContext.BlockReferenceState state
+    ) {
+        validateRepeatedReferenceVersion(operation.version(), state);
+
+        Block block = blockService.getById(state.realBlockId());
+        validateBlockBelongsToDocument(documentId, block);
+        validateBlockVersion(state.currentVersion(), block);
+        return block;
+    }
+
+    private Block resolveFirstExistingBlock(UUID documentId, DocumentTransactionOperationCommand operation) {
+        UUID blockId = parseRealBlockId(operation.blockReference());
+        validateVersionIsPresent(operation.version());
+
+        Block block = blockService.getById(blockId);
+        validateBlockBelongsToDocument(documentId, block);
+        validateBlockVersion(operation.version(), block);
+        return block;
+    }
+
+    private void validateBlockBelongsToDocument(UUID documentId, Block block) {
+        if (!documentId.equals(block.getDocumentId())) {
+            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private void validateBlockVersion(Integer version, Block block) {
+        if (!block.getVersion().equals(version)) {
+            throw new BusinessException(BusinessErrorCode.CONFLICT);
+        }
+    }
+
+    private void validateRepeatedReferenceVersion(
+            Integer version,
+            DocumentTransactionContext.BlockReferenceState state
+    ) {
+        if (state.temporary()) {
+            if (version != null) {
+                throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+            }
+            return;
+        }
+
+        validateVersionIsPresent(version);
+        if (!state.clientVersion().equals(version)) {
+            throw new BusinessException(BusinessErrorCode.CONFLICT);
+        }
+    }
+
+    private void validateVersionIsPresent(Integer version) {
+        if (version == null) {
+            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
+        }
+    }
+
+    private DocumentTransactionOperationStatus resolveAppliedStatus(Integer requestedVersion, Block block) {
+        return block.getVersion().equals(requestedVersion) ? NO_OP : APPLIED;
+    }
+
+    private record ResolvedBlockReference(
+            UUID realBlockId,
+            Integer version,
+            Integer clientVersion,
+            boolean temporary
+    ) {
+    }
+
+    private record ResolvedPositionReferences(UUID parentId, UUID afterBlockId, UUID beforeBlockId) {
+    }
+}

--- a/documents-infrastructure/src/main/java/com/documents/service/DocumentTransactionServiceImpl.java
+++ b/documents-infrastructure/src/main/java/com/documents/service/DocumentTransactionServiceImpl.java
@@ -1,26 +1,21 @@
 package com.documents.service;
 
+import static com.documents.service.transaction.DocumentTransactionOperationStatus.*;
+
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.documents.domain.Block;
-import com.documents.domain.BlockType;
 import com.documents.domain.Document;
 import com.documents.exception.BusinessErrorCode;
 import com.documents.exception.BusinessException;
-import com.documents.repository.BlockRepository;
 import com.documents.repository.DocumentRepository;
 import com.documents.service.transaction.DocumentTransactionAppliedOperationResult;
 import com.documents.service.transaction.DocumentTransactionCommand;
-import com.documents.service.transaction.DocumentTransactionOperationCommand;
-import com.documents.service.transaction.DocumentTransactionOperationStatus;
+import com.documents.service.transaction.DocumentTransactionContext;
 import com.documents.service.transaction.DocumentTransactionResult;
 
 import lombok.RequiredArgsConstructor;
@@ -29,46 +24,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DocumentTransactionServiceImpl implements DocumentTransactionService {
 
-    private static final String EMPTY_TEXT_BLOCK_CONTENT =
-            "{\"format\":\"rich_text\",\"schemaVersion\":1,\"segments\":[{\"text\":\"\",\"marks\":[]}]}";
-
-    private final BlockService blockService;
-    private final BlockRepository blockRepository;
+    private final DocumentTransactionOperationExecutor operationExecutor;
     private final DocumentRepository documentRepository;
 
     @Override
     @Transactional
     public DocumentTransactionResult apply(UUID documentId, DocumentTransactionCommand command, String actorId) {
         Document document = findActiveDocument(documentId);
-
-        Map<String, BlockReferenceContext> blockReferenceContexts = new HashMap<>();
-        List<DocumentTransactionAppliedOperationResult> appliedOperations = new ArrayList<>();
-
-        for (DocumentTransactionOperationCommand operation : command.operations()) {
-            switch (operation.type()) {
-                case BLOCK_CREATE -> appliedOperations.add(
-                        DocumentVersionIncrementContext.runWithoutIncrement(
-                                () -> applyCreate(document, operation, actorId, blockReferenceContexts)
-                        )
-                );
-                case BLOCK_REPLACE_CONTENT -> appliedOperations.add(
-                        DocumentVersionIncrementContext.runWithoutIncrement(
-                                () -> applyReplaceContent(documentId, operation, actorId, blockReferenceContexts)
-                        )
-                );
-                case BLOCK_MOVE -> appliedOperations.add(
-                        DocumentVersionIncrementContext.runWithoutIncrement(
-                                () -> applyMove(documentId, operation, actorId, blockReferenceContexts)
-                        )
-                );
-                case BLOCK_DELETE -> appliedOperations.add(
-                        DocumentVersionIncrementContext.runWithoutIncrement(
-                                () -> applyDelete(documentId, operation, actorId, blockReferenceContexts)
-                        )
-                );
-                default -> throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
-            }
-        }
+        DocumentTransactionContext context = new DocumentTransactionContext();
+        List<DocumentTransactionAppliedOperationResult> appliedOperations = command.operations().stream()
+                .map(operation -> DocumentVersionIncrementContext.runWithoutIncrement(
+                        () -> operationExecutor.apply(documentId, document, operation, actorId, context)
+                ))
+                .toList();
 
         Integer documentVersion = document.getVersion();
         if (hasEditorChange(appliedOperations)) {
@@ -78,290 +46,6 @@ public class DocumentTransactionServiceImpl implements DocumentTransactionServic
         return new DocumentTransactionResult(documentId, documentVersion, command.batchId(), appliedOperations);
     }
 
-    private DocumentTransactionAppliedOperationResult applyCreate(
-            Document document,
-            DocumentTransactionOperationCommand operation,
-            String actorId,
-            Map<String, BlockReferenceContext> blockReferenceContexts
-    ) {
-        validateBlockReferenceIsUnique(operation.blockReference(), blockReferenceContexts);
-        ResolvedPositionReferences resolvedCreatePosition = resolvePositionReferences(operation, blockReferenceContexts);
-
-        Block createdBlock = blockService.create(
-                document,
-                resolvedCreatePosition.parentId(),
-                BlockType.TEXT,
-                EMPTY_TEXT_BLOCK_CONTENT,
-                resolvedCreatePosition.afterBlockId(),
-                resolvedCreatePosition.beforeBlockId(),
-                actorId
-        );
-        blockRepository.flush();
-
-        registerBlockReferenceContext(operation.blockReference(), createdBlock, null, true, blockReferenceContexts);
-
-        return new DocumentTransactionAppliedOperationResult(
-                operation.opId(),
-                DocumentTransactionOperationStatus.APPLIED,
-                operation.blockReference(),
-                createdBlock.getId(),
-                createdBlock.getVersion(),
-                createdBlock.getSortKey(),
-                null
-        );
-    }
-
-    private ResolvedPositionReferences resolvePositionReferences(
-            DocumentTransactionOperationCommand operation,
-            Map<String, BlockReferenceContext> blockReferenceContexts
-    ) {
-        return new ResolvedPositionReferences(
-                resolveOptionalBlockReference(operation.parentReference(), blockReferenceContexts),
-                resolveOptionalBlockReference(operation.afterReference(), blockReferenceContexts),
-                resolveOptionalBlockReference(operation.beforeReference(), blockReferenceContexts)
-        );
-    }
-
-    private DocumentTransactionAppliedOperationResult applyReplaceContent(
-            UUID documentId,
-            DocumentTransactionOperationCommand operation,
-            String actorId,
-            Map<String, BlockReferenceContext> blockReferenceContexts
-    ) {
-        ResolvedBlockReference resolvedBlockReference = resolveBlockReference(documentId, operation, blockReferenceContexts);
-        Block updatedBlock = blockService.update(
-                resolvedBlockReference.realBlockId(),
-                operation.content(),
-                resolvedBlockReference.version(),
-                actorId
-        );
-        blockRepository.flush();
-
-        DocumentTransactionOperationStatus status = resolveAppliedStatus(resolvedBlockReference.version(), updatedBlock);
-
-        registerBlockReferenceContext(
-                operation.blockReference(),
-                updatedBlock,
-                resolvedBlockReference.clientVersion(),
-                resolvedBlockReference.temporary(),
-                blockReferenceContexts
-        );
-
-        return new DocumentTransactionAppliedOperationResult(
-                operation.opId(),
-                status,
-                null,
-                updatedBlock.getId(),
-                updatedBlock.getVersion(),
-                updatedBlock.getSortKey(),
-                null
-        );
-    }
-
-    private DocumentTransactionAppliedOperationResult applyDelete(
-            UUID documentId,
-            DocumentTransactionOperationCommand operation,
-            String actorId,
-            Map<String, BlockReferenceContext> blockReferenceContexts
-    ) {
-        Block block = resolveExistingBlock(documentId, operation, blockReferenceContexts);
-        Block deletedBlock = blockService.delete(block.getId(), block.getVersion(), actorId);
-
-        return new DocumentTransactionAppliedOperationResult(
-                operation.opId(),
-                DocumentTransactionOperationStatus.APPLIED,
-                null,
-                deletedBlock.getId(),
-                null,
-                null,
-                deletedBlock.getDeletedAt()
-        );
-    }
-
-    private DocumentTransactionAppliedOperationResult applyMove(
-            UUID documentId,
-            DocumentTransactionOperationCommand operation,
-            String actorId,
-            Map<String, BlockReferenceContext> blockReferenceContexts
-    ) {
-        ResolvedBlockReference resolvedBlockReference = resolveBlockReference(documentId, operation, blockReferenceContexts);
-        ResolvedPositionReferences resolvedPositionReferences = resolvePositionReferences(operation, blockReferenceContexts);
-
-        Block movedBlock = blockService.move(
-                resolvedBlockReference.realBlockId(),
-                resolvedPositionReferences.parentId(),
-                resolvedPositionReferences.afterBlockId(),
-                resolvedPositionReferences.beforeBlockId(),
-                resolvedBlockReference.version(),
-                actorId
-        );
-        blockRepository.flush();
-
-        DocumentTransactionOperationStatus status = resolveAppliedStatus(resolvedBlockReference.version(), movedBlock);
-
-        registerBlockReferenceContext(
-                operation.blockReference(),
-                movedBlock,
-                resolvedBlockReference.clientVersion(),
-                resolvedBlockReference.temporary(),
-                blockReferenceContexts
-        );
-
-        return new DocumentTransactionAppliedOperationResult(
-                operation.opId(),
-                status,
-                null,
-                movedBlock.getId(),
-                movedBlock.getVersion(),
-                movedBlock.getSortKey(),
-                null
-        );
-    }
-
-    private ResolvedBlockReference resolveBlockReference(
-            UUID documentId,
-            DocumentTransactionOperationCommand operation,
-            Map<String, BlockReferenceContext> blockReferenceContexts
-    ) {
-        BlockReferenceContext blockReferenceContext = findBlockReferenceContext(operation.blockReference(), blockReferenceContexts);
-        if (blockReferenceContext != null) {
-            validateRepeatedReferenceVersion(operation.version(), blockReferenceContext);
-            return new ResolvedBlockReference(
-                    blockReferenceContext.realBlockId(),
-                    blockReferenceContext.currentVersion(),
-                    blockReferenceContext.clientVersion(),
-                    blockReferenceContext.temporary()
-            );
-        }
-
-        Block block = resolveFirstExistingBlock(documentId, operation);
-        return new ResolvedBlockReference(block.getId(), block.getVersion(), operation.version(), false);
-    }
-
-    private void validateBlockReferenceIsUnique(String blockReference, Map<String, BlockReferenceContext> blockReferenceContexts) {
-        if (blockReferenceContexts.containsKey(blockReference)) {
-            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
-        }
-    }
-
-    private UUID resolveOptionalBlockReference(String blockReference, Map<String, BlockReferenceContext> blockReferenceContexts) {
-        if (blockReference == null || blockReference.isBlank()) {
-            return null;
-        }
-
-        BlockReferenceContext blockReferenceContext = findBlockReferenceContext(blockReference, blockReferenceContexts);
-        if (blockReferenceContext != null) {
-            return blockReferenceContext.realBlockId();
-        }
-
-        return parseRealBlockId(blockReference);
-    }
-
-    private void registerBlockReferenceContext(
-            String blockReference,
-            Block block,
-            Integer clientVersion,
-            boolean temporary,
-            Map<String, BlockReferenceContext> blockReferenceContexts
-    ) {
-        blockReferenceContexts.put(
-                blockReference,
-                new BlockReferenceContext(block.getId(), block.getVersion(), clientVersion, temporary)
-        );
-    }
-
-    private BlockReferenceContext findBlockReferenceContext(
-            String blockReference,
-            Map<String, BlockReferenceContext> blockReferenceContexts
-    ) {
-        return blockReferenceContexts.get(blockReference);
-    }
-
-    private UUID parseRealBlockId(String blockReference) {
-        try {
-            return UUID.fromString(blockReference);
-        } catch (IllegalArgumentException ex) {
-            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
-        }
-    }
-
-    private void validateVersionIsPresent(Integer version) {
-        if (version == null) {
-            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
-        }
-    }
-
-    private Block resolveExistingBlock(
-            UUID documentId,
-            DocumentTransactionOperationCommand operation,
-            Map<String, BlockReferenceContext> blockReferenceContexts
-    ) {
-        BlockReferenceContext blockReferenceContext = findBlockReferenceContext(operation.blockReference(), blockReferenceContexts);
-        if (blockReferenceContext != null) {
-            return resolveExistingBlockFromContext(documentId, operation, blockReferenceContext);
-        }
-
-        return resolveFirstExistingBlock(documentId, operation);
-    }
-
-    private Block resolveExistingBlockFromContext(
-            UUID documentId,
-            DocumentTransactionOperationCommand operation,
-            BlockReferenceContext blockReferenceContext
-    ) {
-        validateRepeatedReferenceVersion(operation.version(), blockReferenceContext);
-
-        Block block = blockRepository.findByIdAndDeletedAtIsNull(blockReferenceContext.realBlockId())
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND));
-        validateBlockBelongsToDocument(documentId, block);
-        validateBlockVersion(blockReferenceContext.currentVersion(), block);
-        return block;
-    }
-
-    private Block resolveFirstExistingBlock(UUID documentId, DocumentTransactionOperationCommand operation) {
-        UUID blockId = parseRealBlockId(operation.blockReference());
-        validateVersionIsPresent(operation.version());
-
-        Block block = blockRepository.findByIdAndDeletedAtIsNull(blockId)
-                .orElseThrow(() -> new BusinessException(BusinessErrorCode.BLOCK_NOT_FOUND));
-
-        validateBlockBelongsToDocument(documentId, block);
-        validateBlockVersion(operation.version(), block);
-        return block;
-    }
-
-    private void validateBlockBelongsToDocument(UUID documentId, Block block) {
-        if (!documentId.equals(block.getDocumentId())) {
-            throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
-        }
-    }
-
-    private void validateBlockVersion(Integer version, Block block) {
-        if (!block.getVersion().equals(version)) {
-            throw new BusinessException(BusinessErrorCode.CONFLICT);
-        }
-    }
-
-    private void validateRepeatedReferenceVersion(Integer version, BlockReferenceContext blockReferenceContext) {
-        if (blockReferenceContext.temporary()) {
-            if (version != null) {
-                throw new BusinessException(BusinessErrorCode.INVALID_REQUEST);
-            }
-            return;
-        }
-
-        validateVersionIsPresent(version);
-        if (!blockReferenceContext.clientVersion().equals(version)) {
-            throw new BusinessException(BusinessErrorCode.CONFLICT);
-        }
-    }
-
-    private DocumentTransactionOperationStatus resolveAppliedStatus(Integer requestedVersion, Block block) {
-        return block.getVersion().equals(requestedVersion)
-                ? DocumentTransactionOperationStatus.NO_OP
-                : DocumentTransactionOperationStatus.APPLIED;
-    }
-
     private Document findActiveDocument(UUID documentId) {
         return documentRepository.findByIdAndDeletedAtIsNull(documentId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorCode.DOCUMENT_NOT_FOUND));
@@ -369,7 +53,7 @@ public class DocumentTransactionServiceImpl implements DocumentTransactionServic
 
     private boolean hasEditorChange(List<DocumentTransactionAppliedOperationResult> appliedOperations) {
         return appliedOperations.stream()
-                .anyMatch(result -> result.status() == DocumentTransactionOperationStatus.APPLIED);
+                .anyMatch(result -> result.status() == APPLIED);
     }
 
     private Integer incrementDocumentVersion(UUID documentId, String actorId) {
@@ -379,24 +63,5 @@ public class DocumentTransactionServiceImpl implements DocumentTransactionServic
         }
 
         return findActiveDocument(documentId).getVersion();
-    }
-
-    private record BlockReferenceContext(
-            UUID realBlockId,
-            Integer currentVersion,
-            Integer clientVersion,
-            boolean temporary
-    ) {
-    }
-
-    private record ResolvedBlockReference(
-            UUID realBlockId,
-            Integer version,
-            Integer clientVersion,
-            boolean temporary
-    ) {
-    }
-
-    private record ResolvedPositionReferences(UUID parentId, UUID afterBlockId, UUID beforeBlockId) {
     }
 }

--- a/documents-infrastructure/src/test/java/com/documents/service/DocumentTransactionServiceImplTest.java
+++ b/documents-infrastructure/src/test/java/com/documents/service/DocumentTransactionServiceImplTest.java
@@ -29,6 +29,8 @@ import com.documents.service.transaction.DocumentTransactionOperationCommand;
 import com.documents.service.transaction.DocumentTransactionOperationStatus;
 import com.documents.service.transaction.DocumentTransactionOperationType;
 import com.documents.service.transaction.DocumentTransactionResult;
+import com.documents.support.OrderedSortKeyGenerator;
+import com.documents.support.TextNormalizer;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("Document transaction 서비스 구현 검증")
@@ -53,7 +55,53 @@ class DocumentTransactionServiceImplTest {
 
     @BeforeEach
     void setUp() {
-        documentTransactionService = new DocumentTransactionServiceImpl(blockService, blockRepository, documentRepository);
+        BlockService transactionBlockService = new BlockServiceImpl(
+                blockRepository,
+                documentRepository,
+                new TextNormalizer(),
+                new OrderedSortKeyGenerator()
+        ) {
+            @Override
+            public Block create(
+                    Document document,
+                    UUID parentId,
+                    BlockType type,
+                    String content,
+                    UUID afterBlockId,
+                    UUID beforeBlockId,
+                    String actorId
+            ) {
+                return blockService.create(document, parentId, type, content, afterBlockId, beforeBlockId, actorId);
+            }
+
+            @Override
+            public Block update(UUID blockId, String content, Integer version, String actorId) {
+                return blockService.update(blockId, content, version, actorId);
+            }
+
+            @Override
+            public Block move(
+                    UUID blockId,
+                    UUID parentId,
+                    UUID afterBlockId,
+                    UUID beforeBlockId,
+                    Integer version,
+                    String actorId
+            ) {
+                return blockService.move(blockId, parentId, afterBlockId, beforeBlockId, version, actorId);
+            }
+
+            @Override
+            public Block delete(UUID blockId, Integer version, String actorId) {
+                return blockService.delete(blockId, version, actorId);
+            }
+
+        };
+
+        documentTransactionService = new DocumentTransactionServiceImpl(
+                new DocumentTransactionOperationExecutor(transactionBlockService, blockRepository),
+                documentRepository
+        );
         lenient().when(documentRepository.findByIdAndDeletedAtIsNull(any(UUID.class)))
                 .thenAnswer(invocation -> Optional.of(document(invocation.getArgument(0), 0)));
         lenient().when(documentRepository.incrementVersion(any(UUID.class), anyString(), any(LocalDateTime.class)))

--- a/prompts/2026-03-25-admin-block-transaction-alignment.md
+++ b/prompts/2026-03-25-admin-block-transaction-alignment.md
@@ -1,12 +1,55 @@
 # 2026-03-25 AdminBlock transaction alignment
 
-- Step 1: `AdminBlockController`의 4개 admin block API path/method는 유지하고, request/response 계약과 내부 실행은 `POST /v1/documents/{documentId}/transactions`와 동일한 transaction 모델로 맞춘다.
-- Step 2: update/move/delete 경로는 `blockId`로 대상 블록을 조회해 소속 `documentId`를 해석한 뒤 `DocumentTransactionService.apply(...)`로 위임한다.
-- Step 3: 각 admin API는 자기 역할에 맞는 단일 operation 하나만 허용하고, `blockId`가 있는 경로는 path 값과 body `blockRef` 일치 여부를 검증한다.
-- Step 4: `docs/REQUIREMENTS.md`에 admin block API의 transaction 기반 계약을 반영하고, admin block WebMvc/통합 테스트를 새 계약 기준으로 정리한다.
-- Step 5: 컨트롤러 가독성 기준에 맞지 않는 얇은 helper(`applyTransaction`, `resolveDocumentId`)를 제거하고, 의미가 있는 `validate...` 메서드만 남긴다.
-- Step 6: `AdminBlockController`는 request/response 매핑만 남기고, 단일 operation 검증과 `blockId -> documentId` 해석은 `DocumentTransactionServiceImpl`의 admin 전용 진입점으로 이동했다.
-- Step 7: 컨트롤러는 `DocumentTransactionCommand`에서 `batchId`와 단일 operation만 꺼내 service의 `applyCreate/applyReplaceContent/applyMove/applyDelete`에 직접 넘기고, 실행 컨텍스트 초기화와 단일-operation 검증은 service 내부에 유지했다.
-- Step 8: admin 전용 public API에서 `DocumentTransactionCommand` 오버로드를 제거하고 `batchId + DocumentTransactionOperationCommand` 시그니처만 남겼다. 관련 WebMvc, boot 통합, infrastructure 서비스 테스트까지 새 시그니처 기준으로 검증했다.
-- Step 9: 단건 transaction 진입점과 실제 operation 실행 책임을 `BlockServiceImpl`로 이동하고, `DocumentTransactionServiceImpl`은 batch에서 `BlockService.applyOperation(...)`만 호출하도록 단순화했다. `DocumentTransactionContext`를 core에 추가해 단건/배치가 같은 block reference 컨텍스트를 공유하도록 정리했다.
-- Step 10: `BlockServiceImpl`은 다시 block CRUD 책임만 남기고, admin 단건용 transaction 진입점은 `AdminBlockTransactionServiceImpl`로 분리했다. `DocumentTransactionServiceImpl`과 admin 서비스가 공통 bean `DocumentTransactionOperationExecutor`를 통해 같은 create/replace/move/delete 실행 코어와 `flush` 타이밍을 공유하도록 바꿔 `@Transactional` self-invocation 경고를 제거했다. `AdminBlockControllerWebMvcTest`, `BlockApiIntegrationTest`, `DocumentTransactionServiceImplTest`, `BlockServiceImplTest`까지 재검증했다.
+- 작업 목적: 관리자 전용 단건 블록 API의 외부 엔드포인트는 유지하면서, 내부 처리 방식과 request/response 계약을 기존 에디터 저장 transaction 모델에 맞추도록 정리한다.
+- 관련 요구사항: `docs/REQUIREMENTS.md`
+- 관련 explainer: `docs/explainers/editor-transaction-save-model.md`
+
+## Step 1. 관리자 단건 블록 API를 transaction 계약으로 전환
+
+- `AdminBlockController`의 4개 admin block API는 유지하고, request/response 계약은 `POST /v1/documents/{documentId}/transactions`와 같은 transaction 모델로 맞췄다.
+- create/update/move/delete는 모두 `DocumentTransactionRequest`를 받고 `DocumentTransactionResponse`를 반환하도록 정리했다.
+
+## Step 2. 단건 요청 제약과 block 기준 검증 정리
+
+- 각 admin API는 자기 역할에 맞는 단일 operation 하나만 허용하도록 정리했다.
+- `blockId`가 있는 update/move/delete 요청은 path 값과 body `blockRef` 일치 여부를 검증하도록 맞췄다.
+
+## Step 3. 컨트롤러 책임을 request/response 매핑으로 축소
+
+- 컨트롤러는 `DocumentTransactionCommand`에서 `batchId`와 단일 operation만 꺼내 service의 `applyCreate/applyReplaceContent/applyMove/applyDelete`에 직접 넘기도록 정리했다.
+- 컨트롤러 가독성 기준에 맞지 않는 얇은 helper(`applyTransaction`, `resolveDocumentId`)는 제거하고, HTTP 계층에는 request/response 매핑만 남겼다.
+
+## Step 4. admin 전용 orchestration 계층 추가
+
+- update/move/delete는 `blockId`로 대상 블록을 조회해 소속 `documentId`를 해석한 뒤 공통 실행 코어로 위임하도록 흐름을 바꿨다.
+- 단일 operation 검증, `blockId -> documentId` 해석, 문서 version 증가, 응답 조립은 `AdminBlockTransactionServiceImpl`에서 담당하도록 분리했다.
+- admin 전용 public API는 `DocumentTransactionCommand` 오버로드를 제거하고 `batchId + DocumentTransactionOperationCommand` 시그니처만 남겼다.
+
+## Step 5. 공통 execution 코어 분리
+
+- 단건 transaction 진입점과 실제 operation 실행 책임을 분리하기 위해 `DocumentTransactionOperationExecutor`를 공통 bean으로 추가했다.
+- `DocumentTransactionServiceImpl`과 admin 서비스가 같은 create/replace/move/delete 실행 코어와 `flush` 타이밍을 공유하도록 정리했다.
+- `DocumentTransactionContext`를 core에 추가해 단건/배치가 같은 block reference 컨텍스트를 공유하도록 맞췄다.
+
+## Step 6. block 서비스 책임 재정리
+
+- 단건 transaction 진입점을 한때 `BlockServiceImpl`로 옮겼다가, block CRUD 책임과 orchestration 책임이 섞이지 않도록 admin 단건용 transaction 진입점을 `AdminBlockTransactionServiceImpl`로 다시 분리했다.
+- 결과적으로 `BlockServiceImpl`은 block CRUD와 도메인 규칙 수행 책임만 남기고, transaction orchestration은 admin 서비스와 document transaction 서비스가 담당하도록 정리했다.
+- 이 구조로 `@Transactional` self-invocation 경고가 생기지 않도록 정리했다.
+
+## Step 7. 요구사항과 테스트 정리
+
+- `docs/REQUIREMENTS.md`에 admin block API의 transaction 기반 계약을 반영했다.
+- `AdminBlockControllerWebMvcTest`, `BlockApiIntegrationTest`, `DocumentTransactionServiceImplTest`, `BlockServiceImplTest`를 새 구조 기준으로 정리하고 재검증했다.
+
+## 테스트 실행 결과
+
+- `./gradlew :documents-api:test --tests com.documents.api.block.AdminBlockControllerWebMvcTest --tests com.documents.api.document.DocumentControllerWebMvcTest` 통과
+- `./gradlew :documents-infrastructure:test --tests com.documents.service.AdminBlockTransactionServiceImplTest --tests com.documents.service.DocumentTransactionServiceImplTest --tests com.documents.service.BlockServiceImplTest` 통과
+- `./gradlew :documents-boot:test --tests com.documents.api.block.BlockApiIntegrationTest --tests com.documents.api.document.DocumentTransactionApiIntegrationTest --tests com.documents.api.document.DocumentTransactionConcurrencyIntegrationTest` 통과
+- `./gradlew test` 통과
+
+## 변경 경로
+
+- 요구사항: `docs/REQUIREMENTS.md`
+- 설명 문서: `docs/explainers/editor-transaction-save-model.md`

--- a/prompts/2026-03-25-admin-block-transaction-alignment.md
+++ b/prompts/2026-03-25-admin-block-transaction-alignment.md
@@ -1,0 +1,12 @@
+# 2026-03-25 AdminBlock transaction alignment
+
+- Step 1: `AdminBlockController`의 4개 admin block API path/method는 유지하고, request/response 계약과 내부 실행은 `POST /v1/documents/{documentId}/transactions`와 동일한 transaction 모델로 맞춘다.
+- Step 2: update/move/delete 경로는 `blockId`로 대상 블록을 조회해 소속 `documentId`를 해석한 뒤 `DocumentTransactionService.apply(...)`로 위임한다.
+- Step 3: 각 admin API는 자기 역할에 맞는 단일 operation 하나만 허용하고, `blockId`가 있는 경로는 path 값과 body `blockRef` 일치 여부를 검증한다.
+- Step 4: `docs/REQUIREMENTS.md`에 admin block API의 transaction 기반 계약을 반영하고, admin block WebMvc/통합 테스트를 새 계약 기준으로 정리한다.
+- Step 5: 컨트롤러 가독성 기준에 맞지 않는 얇은 helper(`applyTransaction`, `resolveDocumentId`)를 제거하고, 의미가 있는 `validate...` 메서드만 남긴다.
+- Step 6: `AdminBlockController`는 request/response 매핑만 남기고, 단일 operation 검증과 `blockId -> documentId` 해석은 `DocumentTransactionServiceImpl`의 admin 전용 진입점으로 이동했다.
+- Step 7: 컨트롤러는 `DocumentTransactionCommand`에서 `batchId`와 단일 operation만 꺼내 service의 `applyCreate/applyReplaceContent/applyMove/applyDelete`에 직접 넘기고, 실행 컨텍스트 초기화와 단일-operation 검증은 service 내부에 유지했다.
+- Step 8: admin 전용 public API에서 `DocumentTransactionCommand` 오버로드를 제거하고 `batchId + DocumentTransactionOperationCommand` 시그니처만 남겼다. 관련 WebMvc, boot 통합, infrastructure 서비스 테스트까지 새 시그니처 기준으로 검증했다.
+- Step 9: 단건 transaction 진입점과 실제 operation 실행 책임을 `BlockServiceImpl`로 이동하고, `DocumentTransactionServiceImpl`은 batch에서 `BlockService.applyOperation(...)`만 호출하도록 단순화했다. `DocumentTransactionContext`를 core에 추가해 단건/배치가 같은 block reference 컨텍스트를 공유하도록 정리했다.
+- Step 10: `BlockServiceImpl`은 다시 block CRUD 책임만 남기고, admin 단건용 transaction 진입점은 `AdminBlockTransactionServiceImpl`로 분리했다. `DocumentTransactionServiceImpl`과 admin 서비스가 공통 bean `DocumentTransactionOperationExecutor`를 통해 같은 create/replace/move/delete 실행 코어와 `flush` 타이밍을 공유하도록 바꿔 `@Transactional` self-invocation 경고를 제거했다. `AdminBlockControllerWebMvcTest`, `BlockApiIntegrationTest`, `DocumentTransactionServiceImplTest`, `BlockServiceImplTest`까지 재검증했다.


### PR DESCRIPTION
<!--
제목 작성 요령
[${CONVENTION}] ${구현 내용 요약}

CONVENTION 예시
- [FEAT]  : 새로운 기능 추가
- [FIX]   : 버그 수정
- [REFACTOR] : 코드 리팩터링 (기능 변화 X)
- [CHORE] : 빌드/설정/환경 변경
- [DOCS]  : 문서 수정
-->

## 📝 Part (해당되는 것만 체크)

- [x] BE
- [ ] FE
- [ ] Infra
- [x] Docs
- [x] Test

---

## #️⃣ 연관된 이슈

<!--
이슈와 PR를 자동으로 연결하기 위한 영역입니다.
예시:
- closes #17
- fixes #24
여러 개일 경우 쉼표로 구분해서 적어주세요.
-->

closes #40

---

## 🔎 작업 내용

<!--
무슨 일을 했는지 "한 눈에" 이해할 수 있게 적어주세요.
가능하면 bullet 형식으로 요약해 주세요.
-->

### 1. 주요 변경 사항 요약

- `AdminBlockController` 의 **블록 생성/수정/이동/삭제 API의 내부 처리 방식 및 request/response** 계약을 기존 **에디터 저장 API의 transaction 모델**과 정렬
- `DocumentTransactionOperationExecutor` 를 **공통 실행 코어**로 분리하여, 관리자 블록 API와 에디터 저장 API가 **같은 블록 실행 규칙을 공유**하도록 정리
- 관련 테스트코드 보강 및 수정

### 2. 상세 내용 (선택)

**1. 관리자 전용 블록 CRUD API의 외부 엔드포인트는 유지하고, request/response 계약을 기존 에디터 저장 API의 transaction 모델에 맞추었습니다.**
- 리팩토링 대상 **엔드포인트**는 다음과 같습니다.
  - `POST /v1/admin/documents/{documentId}/blocks`
  - `PATCH /v1/admin/blocks/{blockId}`
  - `DELETE /v1/admin/blocks/{blockId}`
  - `POST /v1/admin/blocks/{blockId}/move`
- 기존 **단건 API 전용 DTO** 대신, `DocumentTransactionRequest` / `DocumentTransactionResponse` 를 사용하도록 변경했습니다.
- 각 API는 request를 `DocumentTransactionCommand` 로 변환한 뒤, `batchId` 와 **단일 operation** 하나만 꺼내서 `AdminBlockTransactionService` 로 전달합니다.<br><br>

**2. 관리자 API마다 허용되는 operation type을 명시적으로 고정하였습니다.**
- **operation type**은 기존 **에디터 저장 API**에서 사용하던 `DocumentTransactionOperationType` 을 그대로 사용합니다.
  - 관리자 블록 생성 API -> `BLOCK_CREATE`
  - 관리자 블록 내용 수정 API -> `BLOCK_REPLACE_CONTENT`
  - 관리자 블록 이동 API -> `BLOCK_MOVE`
  - 관리자 블록 삭제 API -> `BLOCK_DELETE`
- 이러한 방식을 통해 **관리자 단건 블록 API**는 **단건 진입점**이라는 점을 유지하면서도, **내부** `Block` **실행 규칙**은 기존 **에디터 저장 API**의 정책과 **어긋나지 않도록** 고정하였습니다.<br><br>

**3. 관리자 전용 API 처리를 위한 orchestration 계층을 분리하였습니다.**
- `AdminBlockController` -> `AdminBlockTransactionService` -> `AdminBlockTransactionServiceImpl` 로 실행 흐름을 수정하였습니다.
- `AdminBlockTransactionServiceImpl` 은 관리자 전용 4개 API의 단건 요청을 받아 각 API에 맞는 **operation type**과 대상 `Block` 및 `Document` 를 검증한 뒤, 공통 실행 코어로 위임하는 역할입니다.
  - 이는 **관리자 전용 API와 에디터 저장 API가 같은 실행 규칙을 적용**하게 되면서, 양쪽에서 기존 `DocumentTransactionServiceImpl` 를 실행시키는 것은 **단일 책임의 원리(SRP)** 측면에서 어긋난다고 판단했기 때문입니다.
  - 따라서 관리자 단건 API의 **orchestration**과 실제 **Block execution**을 **분리**하여, 관리자 API와 에디터 저장 API가 **공통 execution 코어를 호출**하는 흐름으로 정리하였습니다.<br><br>

**4. 실제 Block operation 실행은 공통 execution 코어를 통해 처리하도록 했습니다.**
- 관리자 블록 CRUD API와 에디터 저장 API는 `DocumentTransactionOperationExecutor` 를 공통 `execution` 코어로 사용합니다.
- 기존에는 에디터 저장 실행 로직이 `DocumentTransactionServiceImpl` 중심으로 묶여 있었는데, 리팩토링을 통해 실제 `Block` operation 실행 책임을 `DocumentTransactionOperationExecutor` 로 분리하였습니다.<br><br>

**5. 리팩토링 관련 테스트를 보강하고, 기존 테스트 통과를 확인하였습니다.**
- `AdminBlockControllerWebMvcTest` , `DocumentTransactionServiceImplTest`  ,`BlockApiIntegrationTest` 등을 리팩토링 구조에 맞게 수정 및 보강하였습니다.

### 3. 프롬프트 경로

- [/prompts/2026-03-25-admin-block-transaction-alignment.md](https://github.com/jho951/Block-server/blob/bf0d8a1b6b5b31ea149883cbfaab99d3ca2f06c4/prompts/2026-03-25-admin-block-transaction-alignment.md)

### 4. 참조 문서 경로 (ADR, discussions, roadMap ...)

_No response_

---

## 💬 집중 리뷰 요청

<!--
리뷰어가 어디를 중점적으로 봐야 하는지 알려주세요.
복잡한 로직, 트레이드오프, 고민했던 포인트를 적어주면 리뷰 품질이 올라갑니다.
-->

- **orchestration**과 **executor**로 분리한 부분이 아키텍처적으로 적절한지 확인 부탁드립니다.

---

## 🧪 테스트 방법

<!--
리뷰어/테스터가 동일하게 재현할 수 있도록, 테스트 방법을 구체적으로 적어주세요.
로컬/스테이징 환경 기준, 실행 커맨드가 있으면 함께 작성해 주세요.
-->

### 1. 로컬 실행 방법

- `./gradlew :documents-api:test --tests com.documents.api.block.AdminBlockControllerWebMvcTest --tests com.documents.api.document.DocumentControllerWebMvcTest`
- `./gradlew :documents-infrastructure:test --tests com.documents.service.AdminBlockTransactionServiceImplTest --tests
  com.documents.service.DocumentTransactionServiceImplTest --tests com.documents.service.BlockServiceImplTest`
- `./gradlew :documents-boot:test --tests com.documents.api.block.BlockApiIntegrationTest --tests com.documents.api.document.DocumentTransactionApiIntegrationTest --tests com.documents.api.document.DocumentTransactionConcurrencyIntegrationTest`
- `./gradlew test`

### 2. 테스트 시나리오

- [x] 관리자 block create API가 `BLOCK_CREATE` 단일 operation 경로로 정상 동작하는지 확인
- [x] 관리자 block update API가 `BLOCK_REPLACE_CONTENT` 단일 operation 경로로 정상 동작하는지 확인
- [x] 관리자 block move API가 `BLOCK_MOVE` 단일 operation 경로로 정상 동작하는지 확인
- [x] 관리자 block delete API가 `BLOCK_DELETE` 단일 operation 경로로 정상 동작하는지 확인
- [x] update / move / delete 요청에서 path `blockId`와 body `blockRef`가 일치하지 않으면 실패하는지 확인
- [x] 관리자 API가 기존 에디터 저장 API 응답 형식과 같은 `DocumentTransactionResponse`를 반환하는지 확인
- [x] 기존 에디터 저장 API가 계속 정상 동작하는지 integration test로 확인
- [x] 관련 전체 테스트가 모두 통과하는지 확인

---

## ✅ PR 체크리스트

<!--
PR 올리기 전에 스스로 한 번 더 점검하는 용도입니다.
팀 컨벤션에 맞게 자유롭게 수정해서 사용하세요.
-->

- [x] 불필요한 디버그 로그 / 주석 제거
- [x] breaking change 여부 확인 및 문서화
- [x] 신규/변경된 기능에 대한 테스트 코드 추가 또는 기존 테스트 통과
- [x] 로컬에서 주요 시나리오 수동 테스트 완료
- [x] 관련 문서(노션, README, API 문서 등) 업데이트

---

## 📈 이미지 / 캡처 (필요 시)

<!--
UI 변경, 에러 화면, API 응답 예시 등이 있다면 이미지로 첨부해주세요.
-->

_No response_