### PR TITLE
Use standalone documents-service compose stack with msa-shared network

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,3 +1,5 @@
+name: documents-service
+
 services:
   mysql:
     image: mysql:8.0
@@ -43,6 +45,16 @@ services:
       - path: ../.env
         required: false
     restart: always
+    networks:
+      default:
+      msa-shared:
+        aliases:
+          - documents-service
 
 volumes:
   mysql_data_dev:
+
+networks:
+  msa-shared:
+    external: true
+    name: ${MSA_SHARED_NETWORK:-msa-shared}

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -1,3 +1,5 @@
+name: documents-service
+
 services:
   mysql:
     image: mysql:8.0
@@ -41,6 +43,16 @@ services:
       - path: ../.env
         required: false
     restart: always
+    networks:
+      default:
+      msa-shared:
+        aliases:
+          - documents-service
 
 volumes:
   mysql_data_prod:
+
+networks:
+  msa-shared:
+    external: true
+    name: ${MSA_SHARED_NETWORK:-msa-shared}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,3 +1,5 @@
+name: documents-service
+
 services:
   mysql:
     image: mysql:8.0
@@ -43,6 +45,16 @@ services:
       - path: ../.env
         required: false
     restart: always
+    networks:
+      default:
+      msa-shared:
+        aliases:
+          - documents-service
 
 volumes:
   mysql_data_dev:
+
+networks:
+  msa-shared:
+    external: true
+    name: ${MSA_SHARED_NETWORK:-msa-shared}

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 DOCKER_DIR="${REPO_ROOT}/docker"
+MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK:-msa-shared}"
 
 ENV_NAME="dev"
 ACTION="up"
@@ -43,34 +44,36 @@ case "${ENV_NAME}" in
     ;;
 esac
 
+docker network inspect "${MSA_SHARED_NETWORK}" >/dev/null 2>&1 || docker network create "${MSA_SHARED_NETWORK}" >/dev/null
+
 case "${ACTION}" in
   all)
-    docker compose -f "${COMPOSE_FILE}" build --no-cache
-    docker compose -f "${COMPOSE_FILE}" up -d
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" build --no-cache
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" up -d
     docker logs "${APP_CONTAINER}" --tail=200 -f
     ;;
   build)
-    docker compose -f "${COMPOSE_FILE}" build
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" build
     ;;
   up)
-    docker compose -f "${COMPOSE_FILE}" up -d
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" up -d
     ;;
   down)
-    docker compose -f "${COMPOSE_FILE}" down
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" down
     ;;
   logs)
-    docker compose -f "${COMPOSE_FILE}" logs -f
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" logs -f
     ;;
   restart)
-    docker compose -f "${COMPOSE_FILE}" down
-    docker compose -f "${COMPOSE_FILE}" up -d
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" down
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" up -d
     ;;
   nuke)
-    docker compose -f "${COMPOSE_FILE}" down -v
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" down -v
     docker image prune -f
     ;;
   ps)
-    docker compose -f "${COMPOSE_FILE}" ps
+    MSA_SHARED_NETWORK="${MSA_SHARED_NETWORK}" docker compose -f "${COMPOSE_FILE}" ps
     ;;
   *)
     echo "지원하지 않는 동작입니다: ${ACTION}"


### PR DESCRIPTION
## Summary
documents-service를 독립 compose stack으로 운영하고, gateway/user/auth와 같은 공통 external 네트워크(msa-shared)에서 DNS 기반으로 연결되도록 정리했습니다.

## What Changed
- docker/docker-compose.dev.yml
  - name: documents-service 추가
  - app 서비스에 msa-shared 네트워크 연결 추가
  - app 서비스에 alias documents-service 추가
  - msa-shared external network 정의 추가
- docker/docker-compose.prod.yml
  - dev와 동일한 구조 반영 (name, msa-shared, alias)
- docker/docker-compose.yml
  - 기본 compose 파일도 동일한 네트워크/alias 구조로 정렬
- scripts/run-docker.sh
  - MSA_SHARED_NETWORK(기본 msa-shared) 변수 도입
  - 실행 전 shared network 자동 생성
  - build/up/down/logs/restart/nuke/ps 전 동작에 MSA_SHARED_NETWORK 주입

## Why
- 서비스를 스택 단위로 독립 배포/관리하기 위함
- gateway가 http://documents-service:8083 형태로 안정적으로 연결되도록 네트워크 DNS를 보장하기 위함
- 로컬/dev/prod compose 파일 간 네트워크 정책 일관성을 맞추기 위함

## Validation
- docker compose -f docker/docker-compose.dev.yml config 통과
- docker compose -f docker/docker-compose.prod.yml config 통과
- docker compose -f docker/docker-compose.yml config 통과

## Notes
- dev 브랜치는 direct push가 정책상 제한되어 PR로 반영 필요
- gateway/auth/user 스택도 동일한 msa-shared 기준으로 정렬된 상태를 전제로 합니다
