### PR TITLE
Hide documents mysql host port exposure

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -11,8 +11,6 @@ services:
       MYSQL_USER: documents
       MYSQL_PASSWORD: documents
       TZ: Asia/Seoul
-    ports:
-      - "3306:3306"
     volumes:
       - mysql_data_dev:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,8 +11,6 @@ services:
       MYSQL_USER: documents
       MYSQL_PASSWORD: documents
       TZ: Asia/Seoul
-    ports:
-      - "3306:3306"
     volumes:
       - mysql_data_dev:/var/lib/mysql
     command: --default-authentication-plugin=mysql_native_password


### PR DESCRIPTION
## Summary
mySQL 포트 비노출 상태로 변경

## Changes
- docker/docker-compose.dev.yml
  - removed mysql port mapping 3306:3306
- docker/docker-compose.yml
  - removed mysql port mapping 3306:3306

## Why
- 직접 포트를 통해 접근할 이유가 없습니다.

## Validation
- docker compose -f docker/docker-compose.dev.yml config
- docker compose -f docker/docker-compose.yml config